### PR TITLE
FIX : test lecteurXML + blocage undo/redo

### DIFF
--- a/AGILE-Hexcalibur/Deliverif/src/controleur/Controleur.java
+++ b/AGILE-Hexcalibur/Deliverif/src/controleur/Controleur.java
@@ -202,11 +202,11 @@ public class Controleur {
     }
     
     public void undo(){
-        this.listeCde.undo();
+        this.etatCourant.undo(this.listeCde);
     }
     
     public void redo(){
-        this.listeCde.redo();
+        this.etatCourant.redo(this.listeCde);
     }
 }
 

--- a/AGILE-Hexcalibur/Deliverif/src/controleur/Etat.java
+++ b/AGILE-Hexcalibur/Deliverif/src/controleur/Etat.java
@@ -73,5 +73,6 @@ interface Etat
     public void zoomPlus(deliverif.Deliverif fenetre, double lat, double lon);
     public void zoomMoins(deliverif.Deliverif fenetre, double lat, double lon);
 
-
+    public void undo(ListeCommandes listeCdes);
+    public void redo(ListeCommandes listeCdes);
 }

--- a/AGILE-Hexcalibur/Deliverif/src/controleur/EtatAjoutLivraison.java
+++ b/AGILE-Hexcalibur/Deliverif/src/controleur/EtatAjoutLivraison.java
@@ -67,4 +67,14 @@ public class EtatAjoutLivraison extends EtatDefaut{
         Controleur.etatCourant = Controleur.ETAT_TOURNEES_CALCULEES;
         fenetre.estAjoutLivraisonFini();
     }
+    
+    @Override
+    public void undo(ListeCommandes listeCde){
+        //L'utilisateur ne peut pas faire d'undo à ce moment-là.
+    }
+    
+    @Override
+    public void redo(ListeCommandes listeCde){
+        //L'utilisateur ne peut pas faire de redo à ce moment-là.
+    }
 }

--- a/AGILE-Hexcalibur/Deliverif/src/controleur/EtatCalculTournees.java
+++ b/AGILE-Hexcalibur/Deliverif/src/controleur/EtatCalculTournees.java
@@ -8,6 +8,8 @@
  */
 package controleur;
 
+import controleur.commandes.ListeCommandes;
+
 /** Etat dans lequel se trouve l'application pendant le calcul des tournées
  *  Permet l'affichage des solutions au fur et à mesure du calcul et l'arrêt du 
  *  calcul si la solution convient.
@@ -38,6 +40,16 @@ public class EtatCalculTournees extends EtatDefaut{
             Controleur.etatCourant=Controleur.ETAT_LIVRAISONS_CHARGEES;
         }
         fenetre.activerBoutonArreterCalcul(true);
+    }
+    
+    @Override
+    public void undo(ListeCommandes listeCde){
+        //Surtout pas d'undo à ce moment-là
+    }
+    
+    @Override
+    public void redo(ListeCommandes listeCde){
+        //Surtout pas de redo non plus.
     }
 
 }

--- a/AGILE-Hexcalibur/Deliverif/src/controleur/EtatDefaut.java
+++ b/AGILE-Hexcalibur/Deliverif/src/controleur/EtatDefaut.java
@@ -112,5 +112,15 @@ public class EtatDefaut implements Etat
     public void zoomPlus(deliverif.Deliverif fenetre, double lat, double lon){}
     @Override
     public void zoomMoins(deliverif.Deliverif fenetre, double lat, double lon){}
+    
+    @Override
+    public void undo(ListeCommandes listeCde){
+        listeCde.undo();//Par défaut
+    }
+    
+    @Override
+    public void redo(ListeCommandes listeCde){
+        listeCde.redo();//Par défaut
+    }
 
 }

--- a/AGILE-Hexcalibur/Deliverif/src/controleur/EtatLivraisonSelectionnee.java
+++ b/AGILE-Hexcalibur/Deliverif/src/controleur/EtatLivraisonSelectionnee.java
@@ -62,4 +62,14 @@ public class EtatLivraisonSelectionnee extends EtatDefaut {
         fenetre.estPointPassageASupprimerSelectionne(intersection.getPosition().getLatitude(), intersection.getPosition().getLongitude());
         this.livraisonASupprimer = intersection;
     }
+    
+    @Override
+    public void undo(ListeCommandes listeCde){
+        //L'utilisateur ne peut pas faire de undo à ce moment-là.
+    }
+    
+    @Override
+    public void redo(ListeCommandes listeCde){
+        //L'utilisateur ne peut pas faire de redo à ce moment-là.
+    }
 }

--- a/AGILE-Hexcalibur/Deliverif/src/modele/flux/LecteurXML.java
+++ b/AGILE-Hexcalibur/Deliverif/src/modele/flux/LecteurXML.java
@@ -112,6 +112,9 @@ public class LecteurXML {
                            .filter(a -> Objects.equals(a.getIdXML(), destination))
                            .collect(Collectors.toList()).get(0);
                    float longueur = Float.parseFloat(eNoeud.getAttribute("longueur"));
+                   if (longueur<0){
+                       continue;//Pas de troncon négatif !
+                   }
                    Troncon troncon = new Troncon(nomRue, debut, fin, longueur);
                    
                    //ajout du tronçon à la liste des tronçons du plan de la ville

--- a/AGILE-Hexcalibur/Deliverif/src/modele/flux/LecteurXML.java
+++ b/AGILE-Hexcalibur/Deliverif/src/modele/flux/LecteurXML.java
@@ -172,6 +172,9 @@ public class LecteurXML {
             
             //Intégration des livraisons à l'instance demande de lobjet DemandeLivraison
             NodeList listeNoeudsXML = documentXML.getElementsByTagName("livraison");
+            if (listeNoeudsXML.getLength()==0){
+                throw new IndexOutOfBoundsException("Pas de livraison dans cette demande !");
+            }
             List<PointPassage> listeLivraisons = new ArrayList<>();
             for (int temp = 0; temp < listeNoeudsXML.getLength(); temp++) {
                 Node noeud = listeNoeudsXML.item(temp);

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/LecteurXMLTest.java
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/LecteurXMLTest.java
@@ -8,18 +8,18 @@ package modele.flux;
 import java.io.IOException;
 import modele.outils.DemandeLivraison;
 import modele.outils.PlanVille;
-import modele.outils.Troncon;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import org.w3c.dom.Document;
 
 /**
  *
  * @author Amine Nahid
  */
 public class LecteurXMLTest {
+    
+    private final String url = "test/modele/flux/";
     
     public LecteurXMLTest() {
     }
@@ -53,33 +53,88 @@ public class LecteurXMLTest {
         System.out.println("creerPlanVille");
         String urlFichierXML = "test/modele/flux/moyenPlan.xml";
         LecteurXML instance = new LecteurXML();
-        String expResult1 = "Rue Danton";
         PlanVille pv = instance.creerPlanVille(urlFichierXML);
         String result1 = pv.getTroncons().get(0).getNom();
-        System.out.println(result1);
-        assertEquals(expResult1, result1);
-        int expResult2 = 25175791;
+        assertEquals("", result1);
         long result2 = instance.creerPlanVille(urlFichierXML).getIntersections().get(0).getIdXML();
-        System.out.println(result2);
-        assertEquals(expResult2, result2);
+        assertEquals(2129259178, result2);
     }
     
     /**
      * Test of creerDemandeLivraison method, of class LecteurXML.
      */
     @Test
-    public void testCreerDemandeLivraison() throws IOException, Exception {
-        System.out.println("creerDemandeLivraison");
+    public void testCreerDemandeLivraison(){
+        System.out.println("-- creerDemandeLivraison");
         String urlFichierPlan = "test/modele/flux/moyenPlan.xml";
         String urlFichierXML = "test/modele/flux/dl-moyen-12.xml";
         LecteurXML instance = new LecteurXML();
-        PlanVille planVille = instance.creerPlanVille(urlFichierPlan);
-        String expResult = "Rue Danton";
-        String result = instance.creerDemandeLivraison(urlFichierXML, planVille).getEntrepot().getPosition().getTroncon(0).getNom();
-        System.out.println(result);
-        String result2 = instance.creerDemandeLivraison(urlFichierXML, planVille).getLivraisons().get(0).getPosition().getTroncon(0).getNom();
-        System.out.println(result2);
-        assertEquals(expResult, result);
-        assertEquals(expResult, result2);
+        try{
+            PlanVille planVille = instance.creerPlanVille(urlFichierPlan);
+            String result = instance.creerDemandeLivraison(urlFichierXML, planVille).getEntrepot().getPosition().getTroncon(0).getNom();
+            String result2 = instance.creerDemandeLivraison(urlFichierXML, planVille).getLivraisons().get(0).getPosition().getTroncon(0).getNom();
+            assertEquals("Rue Pierre Verger", result);
+            assertEquals("Cours Tolstoï", result2);
+        } catch(Exception e){
+            fail(e.getStackTrace().toString());
+        }
+    }
+    
+    /**
+     * Test d'un plan cassé :
+     * - Un fichier n'est pas syntaxiquement correct
+     * - Il manque un attribut dans un noeud
+     * - Il manque un attribut dans un troncon
+     * - Un troncon réfère un noeud inexistant
+     * - On passe une demande de livraison à la place d'un plan
+     * - On donne quelque chose qui n'a rien à voir
+     */
+    @Test
+    public void testPlanCasse(){
+        System.out.println("-- test plan cassé");
+        String[] fichiers = {url+"planCasse0.xml", url+"planCasse1.xml", url+"planCasse2.xml",
+        url+"planCasse3.xml", url+"dl-petit3.xml", "src/modele/outils/TemplateTSP.java"};
+        LecteurXML lecteur = new LecteurXML();
+        for(String fichier : fichiers){
+            
+            try{
+                PlanVille ville = lecteur.creerPlanVille(fichier);
+                fail("Le plan cassé "+fichier+" a tout de même passé.");
+            } catch(Exception e) {}
+        }
+    }
+    
+    /**
+     * Test d'une demande de livraison cassée
+     * - La livraison est chargée avant un plan
+     * - Une livraison n'est pas au bon format (caractère manquant
+     * - Une livraison n'a pas d'entrepot
+     * - Une livraison n'a pas de livraison
+     * - Une livraison réfère un noeud inexistant
+     * - Un fichier qui n'a vraiment rien à voir
+     */
+    @Test
+    public void testDemandeLivraisonCassee(){
+        System.out.println("-- test dl cassé");
+        LecteurXML lecteur = new LecteurXML();
+        try{
+            DemandeLivraison dl = lecteur.creerDemandeLivraison(url+"dl-petit3.xml", null);
+            fail("La création d'une DL a eu lieu malgré l'absence de plan !");
+        } catch(Exception e) {}
+        String[] fichiers = {url+"dlCasse0.xml", url+"dlCasse1.xml", url+"dlCasse2.xml",
+            url+"dlCasse3.xml", "src/modele/outils/TemplateTSP.java"};
+        //Nous avons maintenant besoin d'une ville.
+        PlanVille ville=null;
+        try{
+            ville=lecteur.creerPlanVille(url+"petitPlan.xml");
+        } catch(Exception e){
+            fail("Le plan n'a pas été chargé : "+e.getMessage());
+        }
+        for(String fichier : fichiers){
+            try{
+                DemandeLivraison dl = lecteur.creerDemandeLivraison(fichier, ville);
+                fail("Le fichier "+fichier+" a tout de même été lu");
+            } catch(Exception e) {}
+        }
     }
 }

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/LecteurXMLTest.java
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/LecteurXMLTest.java
@@ -86,6 +86,7 @@ public class LecteurXMLTest {
      * - Il manque un attribut dans un noeud
      * - Il manque un attribut dans un troncon
      * - Un troncon réfère un noeud inexistant
+     * - Un troncon possède une longueur négative (ce qui démolit dijkstra)
      * - On passe une demande de livraison à la place d'un plan
      * - On donne quelque chose qui n'a rien à voir
      */
@@ -93,24 +94,31 @@ public class LecteurXMLTest {
     public void testPlanCasse(){
         System.out.println("-- test plan cassé");
         String[] fichiers = {url+"planCasse0.xml", url+"planCasse1.xml", url+"planCasse2.xml",
-        url+"planCasse3.xml", url+"dl-petit3.xml", "src/modele/outils/TemplateTSP.java"};
+        url+"planCasse3.xml", url+"planCasse4.xml", url+"dl-petit3.xml", "src/modele/outils/TemplateTSP.java"};
         LecteurXML lecteur = new LecteurXML();
         for(String fichier : fichiers){
             
             try{
                 PlanVille ville = lecteur.creerPlanVille(fichier);
-                fail("Le plan cassé "+fichier+" a tout de même passé.");
-            } catch(Exception e) {}
+                if (!fichier.equals(fichiers[4])){
+                    fail("Le plan cassé "+fichier+" a tout de même passé.");
+                }
+            } catch(Exception e) {
+                if(fichier.equals(fichiers[4])){
+                    fail("La longueur négative génère une exception");
+                }
+            }
         }
     }
     
     /**
      * Test d'une demande de livraison cassée
-     * - La livraison est chargée avant un plan
-     * - Une livraison n'est pas au bon format (caractère manquant
-     * - Une livraison n'a pas d'entrepot
-     * - Une livraison n'a pas de livraison
+     * - La dl est chargée avant un plan
+     * - Une dl n'est pas au bon format (caractère manquant)
+     * - Une dl n'a pas d'entrepot
+     * - Une dl n'a pas de livraison
      * - Une livraison réfère un noeud inexistant
+     * - Une livraison avec un attribut manquant
      * - Un fichier qui n'a vraiment rien à voir
      */
     @Test
@@ -122,7 +130,7 @@ public class LecteurXMLTest {
             fail("La création d'une DL a eu lieu malgré l'absence de plan !");
         } catch(Exception e) {}
         String[] fichiers = {url+"dlCasse0.xml", url+"dlCasse1.xml", url+"dlCasse2.xml",
-            url+"dlCasse3.xml", "src/modele/outils/TemplateTSP.java"};
+            url+"dlCasse3.xml", url+"dlCasse4.xml", "src/modele/outils/TemplateTSP.java"};
         //Nous avons maintenant besoin d'une ville.
         PlanVille ville=null;
         try{

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/PlanCasse2.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/PlanCasse2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Plan cassé car un attribut manquant-->
+<reseau>
+<noeud id="1" latitude="0" longitude="0"/>
+<noeud id="2" latitude="1" longitude="1"/>
+<troncon destination="1" nomRue="Rue 1" origine="2"/>
+</reseau>

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/PlanCasse3.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/PlanCasse3.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Plan cassé car un attribut manquant-->
+<reseau>
+<noeud id="1" latitude="0" longitude="0"/>
+<troncon destination="1" longueur="10" nomRue="Rue 1" origine="2"/>
+</reseau>

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse0.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse0.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<demandeDeLivraisons>
+<entrepot adresse="48830472" heureDepart="8:0:0"/>
+<livraison adresse="26317242" duree="60"/
+<livraison adresse="2650077854" duree="180"/>
+<livraison adresse="55475025" duree="60"/>
+</demandeDeLivraisons>
+

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse1.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<demandeDeLivraisons>
+<livraison adresse="26317242" duree="60"/>
+<livraison adresse="2650077854" duree="180"/>
+<livraison adresse="55475025" duree="60"/>
+</demandeDeLivraisons>
+

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse2.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<demandeDeLivraisons>
+<entrepot adresse="48830472" heureDepart="8:0:0"/>
+</demandeDeLivraisons>
+

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse3.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse3.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<demandeDeLivraisons>
+<entrepot adresse="48830472" heureDepart="8:0:0"/>
+<livraison adresse="1" duree="60"/>
+<livraison adresse="2650077854" duree="180"/>
+<livraison adresse="55475025" duree="60"/>
+</demandeDeLivraisons>
+

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse4.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/dlCasse4.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<demandeDeLivraisons>
+<entrepot adresse="25611425" heureDepart="8:0:0"/>
+<livraison adresse="26079802" duree="180"/>
+<livraison duree="360"/>
+<livraison adresse="479185301" duree="60"/>
+<livraison adresse="3267479470" duree="120"/>
+<livraison adresse="26317293" duree="300"/>
+<livraison adresse="55474973" duree="180"/>
+</demandeDeLivraisons>

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/planCasse0.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/planCasse0.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Plan cassé car un attribut manquant-->
+<reseau>
+<noeud id="1" latitude="0" longitude="0"/>
+<noeud id="2" latitude="1">
+<troncon destination="1" longueur="10" nomRue="Rue 1" origine="2"/>
+</reseau>

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/planCasse1.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/planCasse1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--Plan cassé car un attribut manquant-->
+<reseau>
+<noeud id="1" latitude="0" longitude="0"/>
+<noeud id="2" latitude="1"/>
+<troncon destination="1" longueur="10" nomRue="Rue 1" origine="2"/>
+</reseau>

--- a/AGILE-Hexcalibur/Deliverif/test/modele/flux/planCasse4.xml
+++ b/AGILE-Hexcalibur/Deliverif/test/modele/flux/planCasse4.xml
@@ -1,0 +1,928 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<reseau>
+<noeud id="25175791" latitude="45.75406" longitude="4.857418"/>
+<noeud id="2129259178" latitude="45.750404" longitude="4.8744674"/>
+<noeud id="26086130" latitude="45.75871" longitude="4.8704023"/>
+<noeud id="2129259176" latitude="45.75171" longitude="4.8718166"/>
+<noeud id="479185301" latitude="45.750896" longitude="4.859119"/>
+<noeud id="25611760" latitude="45.754536" longitude="4.866525"/>
+<noeud id="25303831" latitude="45.74979" longitude="4.87572"/>
+<noeud id="479185303" latitude="45.751904" longitude="4.857877"/>
+<noeud id="25303832" latitude="45.749344" longitude="4.876714"/>
+<noeud id="25303833" latitude="45.748894" longitude="4.877902"/>
+<noeud id="33066088" latitude="45.759098" longitude="4.8617606"/>
+<noeud id="2129259180" latitude="45.750214" longitude="4.8742905"/>
+<noeud id="26316433" latitude="45.75862" longitude="4.870949"/>
+<noeud id="25468070" latitude="45.76204" longitude="4.862937"/>
+<noeud id="26086121" latitude="45.760586" longitude="4.866353"/>
+<noeud id="26086122" latitude="45.760376" longitude="4.8680854"/>
+<noeud id="26086120" latitude="45.761326" longitude="4.8646603"/>
+<noeud id="26086126" latitude="45.75925" longitude="4.865438"/>
+<noeud id="26086123" latitude="45.762226" longitude="4.868497"/>
+<noeud id="26086124" latitude="45.759098" longitude="4.8629594"/>
+<noeud id="26086129" latitude="45.759094" longitude="4.867803"/>
+<noeud id="25152444" latitude="45.747326" longitude="4.858333"/>
+<noeud id="26086127" latitude="45.75929" longitude="4.8660555"/>
+<noeud id="26086128" latitude="45.759357" longitude="4.8678627"/>
+<noeud id="479185309" latitude="45.752026" longitude="4.858831"/>
+<noeud id="208776568" latitude="45.758827" longitude="4.869551"/>
+<noeud id="495424862" latitude="45.752663" longitude="4.857675"/>
+<noeud id="25468067" latitude="45.762028" longitude="4.864684"/>
+<noeud id="25175778" latitude="45.75343" longitude="4.8574653"/>
+<noeud id="25611411" latitude="45.75486" longitude="4.879142"/>
+<noeud id="26316432" latitude="45.75836" longitude="4.872581"/>
+<noeud id="25303800" latitude="45.747585" longitude="4.877618"/>
+<noeud id="25611425" latitude="45.754944" longitude="4.8772635"/>
+<noeud id="25611428" latitude="45.75478" longitude="4.87484"/>
+<noeud id="25611424" latitude="45.754955" longitude="4.8783345"/>
+<noeud id="26316429" latitude="45.7573" longitude="4.8731403"/>
+<noeud id="1345284783" latitude="45.752106" longitude="4.8660784"/>
+<noeud id="26317212" latitude="45.753757" longitude="4.8719707"/>
+<noeud id="55475018" latitude="45.75978" longitude="4.875795"/>
+<noeud id="25321469" latitude="45.748405" longitude="4.875445"/>
+<noeud id="25335981" latitude="45.750526" longitude="4.8685336"/>
+<noeud id="2069548756" latitude="45.761852" longitude="4.8579416"/>
+<noeud id="26317209" latitude="45.754433" longitude="4.8718023"/>
+<noeud id="26317207" latitude="45.75405" longitude="4.86861"/>
+<noeud id="2672660419" latitude="45.756004" longitude="4.8742256"/>
+<noeud id="25321357" latitude="45.747253" longitude="4.8703413"/>
+<noeud id="55475004" latitude="45.759575" longitude="4.8759494"/>
+<noeud id="565375197" latitude="45.753437" longitude="4.871185"/>
+<noeud id="25321359" latitude="45.747795" longitude="4.872455"/>
+<noeud id="26079802" latitude="45.754997" longitude="4.8576107"/>
+<noeud id="26317214" latitude="45.754124" longitude="4.867271"/>
+<noeud id="26079801" latitude="45.754852" longitude="4.8574104"/>
+<noeud id="26079800" latitude="45.75513" longitude="4.8574104"/>
+<noeud id="26317312" latitude="45.753" longitude="4.8787503"/>
+<noeud id="26317310" latitude="45.75405" longitude="4.878974"/>
+<noeud id="459797866" latitude="45.75379" longitude="4.874625"/>
+<noeud id="459797864" latitude="45.75356" longitude="4.8737674"/>
+<noeud id="55475038" latitude="45.759636" longitude="4.875504"/>
+<noeud id="26086114" latitude="45.761364" longitude="4.862966"/>
+<noeud id="26086115" latitude="45.761345" longitude="4.863875"/>
+<noeud id="459797860" latitude="45.7518" longitude="4.873133"/>
+<noeud id="26086118" latitude="45.761295" longitude="4.8664956"/>
+<noeud id="26086119" latitude="45.76131" longitude="4.8654766"/>
+<noeud id="26086117" latitude="45.761303" longitude="4.868284"/>
+<noeud id="2117622744" latitude="45.757072" longitude="4.8586116"/>
+<noeud id="2117622742" latitude="45.75619" longitude="4.858778"/>
+<noeud id="1679901320" latitude="45.762653" longitude="4.875565"/>
+<noeud id="55475025" latitude="45.759773" longitude="4.8756394"/>
+<noeud id="25303840" latitude="45.7522" longitude="4.874652"/>
+<noeud id="208769091" latitude="45.759727" longitude="4.8709283"/>
+<noeud id="25303841" latitude="45.75184" longitude="4.87654"/>
+<noeud id="25334442" latitude="45.74966" longitude="4.865105"/>
+<noeud id="2117622739" latitude="45.755558" longitude="4.858861"/>
+<noeud id="2117622731" latitude="45.755" longitude="4.8590035"/>
+<noeud id="250042857" latitude="45.754208" longitude="4.8638077"/>
+<noeud id="26317313" latitude="45.753277" longitude="4.8788133"/>
+<noeud id="25321302" latitude="45.749954" longitude="4.8637676"/>
+<noeud id="25321422" latitude="45.749027" longitude="4.873145"/>
+<noeud id="25321304" latitude="45.74843" longitude="4.8656287"/>
+<noeud id="342869317" latitude="45.759945" longitude="4.87886"/>
+<noeud id="3870641969" latitude="45.75985" longitude="4.8724995"/>
+<noeud id="2117622723" latitude="45.75425" longitude="4.8591485"/>
+<noeud id="2117622721" latitude="45.753757" longitude="4.8601513"/>
+<noeud id="4428355731" latitude="45.750877" longitude="4.8608565"/>
+<noeud id="3870641963" latitude="45.759747" longitude="4.872273"/>
+<noeud id="26317248" latitude="45.753586" longitude="4.871547"/>
+<noeud id="26057083" latitude="45.756855" longitude="4.86569"/>
+<noeud id="25321433" latitude="45.74969" longitude="4.873468"/>
+<noeud id="1682387619" latitude="45.752823" longitude="4.8751845"/>
+<noeud id="26057084" latitude="45.756714" longitude="4.8673143"/>
+<noeud id="26057085" latitude="45.756638" longitude="4.8683963"/>
+<noeud id="26317260" latitude="45.75318" longitude="4.875235"/>
+<noeud id="1682387615" latitude="45.752647" longitude="4.8724184"/>
+<noeud id="33065949" latitude="45.759" longitude="4.861726"/>
+<noeud id="26317259" latitude="45.753216" longitude="4.8756714"/>
+<noeud id="342867241" latitude="45.76051" longitude="4.879188"/>
+<noeud id="26317234" latitude="45.75526" longitude="4.8726516"/>
+<noeud id="26317235" latitude="45.754982" longitude="4.865772"/>
+<noeud id="26317232" latitude="45.75503" longitude="4.8707204"/>
+<noeud id="26317233" latitude="45.754574" longitude="4.8668556"/>
+<noeud id="25321687" latitude="45.75154" longitude="4.87438"/>
+<noeud id="25321327" latitude="45.74706" longitude="4.8751974"/>
+<noeud id="25321447" latitude="45.750668" longitude="4.8739367"/>
+<noeud id="25321689" latitude="45.751118" longitude="4.876261"/>
+<noeud id="254567104" latitude="45.762047" longitude="4.862103"/>
+<noeud id="342868447" latitude="45.76004" longitude="4.877385"/>
+<noeud id="26057064" latitude="45.75704" longitude="4.8625107"/>
+<noeud id="26317229" latitude="45.75465" longitude="4.8674865"/>
+<noeud id="26317228" latitude="45.755142" longitude="4.871614"/>
+<noeud id="26057069" latitude="45.75693" longitude="4.86464"/>
+<noeud id="254581659" latitude="45.762287" longitude="4.8576846"/>
+<noeud id="26317246" latitude="45.7529" longitude="4.8740664"/>
+<noeud id="25321330" latitude="45.747303" longitude="4.873961"/>
+<noeud id="25321456" latitude="45.749214" longitude="4.875591"/>
+<noeud id="26317242" latitude="45.75426" longitude="4.8732033"/>
+<noeud id="25321334" latitude="45.747627" longitude="4.872355"/>
+<noeud id="26057062" latitude="45.757103" longitude="4.8616505"/>
+<noeud id="26086307" latitude="45.751766" longitude="4.8568363"/>
+<noeud id="25335974" latitude="45.748856" longitude="4.868323"/>
+<noeud id="26057055" latitude="45.757072" longitude="4.8587456"/>
+<noeud id="92375972" latitude="45.75687" longitude="4.8576"/>
+<noeud id="26317236" latitude="45.75603" longitude="4.864057"/>
+<noeud id="92375975" latitude="45.757076" longitude="4.857793"/>
+<noeud id="92375974" latitude="45.756714" longitude="4.857779"/>
+<noeud id="26317294" latitude="45.752865" longitude="4.877914"/>
+<noeud id="1423439485" latitude="45.76235" longitude="4.878438"/>
+<noeud id="26317293" latitude="45.752815" longitude="4.8769016"/>
+<noeud id="55463792" latitude="45.75585" longitude="4.876966"/>
+<noeud id="25468041" latitude="45.762028" longitude="4.8638415"/>
+<noeud id="55463789" latitude="45.755737" longitude="4.876579"/>
+<noeud id="26576954" latitude="45.747383" longitude="4.858934"/>
+<noeud id="26576955" latitude="45.74725" longitude="4.8587947"/>
+<noeud id="1368674810" latitude="45.75577" longitude="4.876167"/>
+<noeud id="26576953" latitude="45.747192" longitude="4.859119"/>
+<noeud id="1368674811" latitude="45.75587" longitude="4.876154"/>
+<noeud id="3870640550" latitude="45.75942" longitude="4.872516"/>
+<noeud id="2069548810" latitude="45.762756" longitude="4.859692"/>
+<noeud id="55463799" latitude="45.755966" longitude="4.876903"/>
+<noeud id="26576965" latitude="45.758797" longitude="4.8583546"/>
+<noeud id="55463796" latitude="45.756237" longitude="4.8778014"/>
+<noeud id="26576963" latitude="45.755165" longitude="4.8591056"/>
+<noeud id="251171098" latitude="45.751587" longitude="4.8779144"/>
+<noeud id="26576964" latitude="45.75771" longitude="4.858617"/>
+<noeud id="26317393" latitude="45.75209" longitude="4.8788476"/>
+<noeud id="26121686" latitude="45.74841" longitude="4.859172"/>
+<noeud id="522100855" latitude="45.751476" longitude="4.866085"/>
+<noeud id="2365376415" latitude="45.748672" longitude="4.8785987"/>
+<noeud id="25321408" latitude="45.748898" longitude="4.873075"/>
+<noeud id="25321407" latitude="45.748512" longitude="4.8728576"/>
+<noeud id="21993013" latitude="45.74786" longitude="4.8624663"/>
+<noeud id="54803125" latitude="45.762478" longitude="4.870813"/>
+<noeud id="54803121" latitude="45.762657" longitude="4.872357"/>
+<noeud id="54803122" latitude="45.76158" longitude="4.8708496"/>
+<noeud id="1368674809" latitude="45.755665" longitude="4.8761983"/>
+<noeud id="251050862" latitude="45.75084" longitude="4.8726606"/>
+<noeud id="1603856892" latitude="45.752464" longitude="4.870312"/>
+<noeud id="21993017" latitude="45.748215" longitude="4.863507"/>
+<noeud id="21993015" latitude="45.747337" longitude="4.865067"/>
+<noeud id="54803119" latitude="45.761772" longitude="4.8724155"/>
+<noeud id="2456932713" latitude="45.760902" longitude="4.877833"/>
+<noeud id="33065924" latitude="45.75878" longitude="4.858702"/>
+<noeud id="1368674802" latitude="45.75492" longitude="4.8753004"/>
+<noeud id="26057098" latitude="45.75631" longitude="4.871078"/>
+<noeud id="2129259173" latitude="45.751522" longitude="4.871599"/>
+<noeud id="1368674800" latitude="45.754917" longitude="4.876105"/>
+<noeud id="1368674806" latitude="45.755222" longitude="4.876136"/>
+<noeud id="3393859927" latitude="45.749573" longitude="4.8595033"/>
+<noeud id="251047560" latitude="45.751255" longitude="4.8727455"/>
+<noeud id="1036842196" latitude="45.75098" longitude="4.859755"/>
+<noeud id="3393859920" latitude="45.749447" longitude="4.8603206"/>
+<noeud id="1036842078" latitude="45.749855" longitude="4.859729"/>
+<noeud id="208769120" latitude="45.759434" longitude="4.869736"/>
+<noeud id="55457354" latitude="45.762676" longitude="4.8782406"/>
+<noeud id="26033277" latitude="45.756165" longitude="4.8574095"/>
+<noeud id="3370328152" latitude="45.76138" longitude="4.8620934"/>
+<noeud id="3393859930" latitude="45.74965" longitude="4.859534"/>
+<noeud id="208769112" latitude="45.75941" longitude="4.86923"/>
+<noeud id="251050719" latitude="45.752224" longitude="4.874003"/>
+<noeud id="1288817934" latitude="45.749992" longitude="4.8702283"/>
+<noeud id="251047558" latitude="45.752396" longitude="4.873476"/>
+<noeud id="3393859904" latitude="45.749123" longitude="4.8594327"/>
+<noeud id="48830472" latitude="45.758003" longitude="4.874931"/>
+<noeud id="26057106" latitude="45.7561" longitude="4.8726816"/>
+<noeud id="48830470" latitude="45.75691" longitude="4.8763556"/>
+<noeud id="48830471" latitude="45.757717" longitude="4.876506"/>
+<noeud id="26057109" latitude="45.757126" longitude="4.8746276"/>
+<noeud id="2026239409" latitude="45.752804" longitude="4.869617"/>
+<noeud id="208769227" latitude="45.759556" longitude="4.8696303"/>
+<noeud id="55463805" latitude="45.75561" longitude="4.8755274"/>
+<noeud id="26577743" latitude="45.762623" longitude="4.8575273"/>
+<noeud id="1368674799" latitude="45.7549" longitude="4.87564"/>
+<noeud id="48830474" latitude="45.75852" longitude="4.8765216"/>
+<noeud id="48833743" latitude="45.76003" longitude="4.866216"/>
+<noeud id="208769334" latitude="45.759197" longitude="4.8769765"/>
+<noeud id="48833747" latitude="45.759834" longitude="4.867973"/>
+<noeud id="208769457" latitude="45.760174" longitude="4.877455"/>
+<noeud id="48833748" latitude="45.7601" longitude="4.8654733"/>
+<noeud id="251171031" latitude="45.75276" longitude="4.8784537"/>
+<noeud id="208769219" latitude="45.759624" longitude="4.8697677"/>
+<noeud id="55463812" latitude="45.754936" longitude="4.876986"/>
+<noeud id="249801845" latitude="45.754467" longitude="4.863723"/>
+<noeud id="1703401805" latitude="45.749405" longitude="4.866139"/>
+<noeud id="195271" latitude="45.7512" longitude="4.8685937"/>
+<noeud id="195270" latitude="45.751556" longitude="4.865392"/>
+<noeud id="195262" latitude="45.74992" longitude="4.8604593"/>
+<noeud id="195261" latitude="45.753925" longitude="4.8615813"/>
+<noeud id="195263" latitude="45.750793" longitude="4.86073"/>
+<noeud id="195266" latitude="45.75" longitude="4.8644643"/>
+<noeud id="55463826" latitude="45.75659" longitude="4.8790674"/>
+<noeud id="195268" latitude="45.75073" longitude="4.8650455"/>
+<noeud id="4193445730" latitude="45.756573" longitude="4.8789897"/>
+<noeud id="1682387539" latitude="45.749924" longitude="4.8719816"/>
+<noeud id="1259561375" latitude="45.75071" longitude="4.870559"/>
+<noeud id="25336175" latitude="45.75301" longitude="4.863642"/>
+<noeud id="25336178" latitude="45.752552" longitude="4.8658633"/>
+<noeud id="4193445733" latitude="45.757183" longitude="4.878625"/>
+<noeud id="25719228" latitude="45.74938" longitude="4.8602924"/>
+<noeud id="208769312" latitude="45.759335" longitude="4.877039"/>
+<noeud id="195273" latitude="45.749615" longitude="4.8684645"/>
+<noeud id="195272" latitude="45.749878" longitude="4.868472"/>
+<noeud id="195275" latitude="45.747925" longitude="4.8676333"/>
+<noeud id="195274" latitude="45.7489" longitude="4.8681254"/>
+<noeud id="195276" latitude="45.74762" longitude="4.865224"/>
+<noeud id="2835339775" latitude="45.758167" longitude="4.8668036"/>
+<noeud id="2835339774" latitude="45.757305" longitude="4.8666577"/>
+<noeud id="55474983" latitude="45.75947" longitude="4.8756676"/>
+<noeud id="25336189" latitude="45.752617" longitude="4.8687177"/>
+<noeud id="55474989" latitude="45.75948" longitude="4.87583"/>
+<noeud id="25173835" latitude="45.75045" longitude="4.8569613"/>
+<noeud id="25336179" latitude="45.754128" longitude="4.863194"/>
+<noeud id="208769303" latitude="45.75924" longitude="4.877136"/>
+<noeud id="55474973" latitude="45.76165" longitude="4.875242"/>
+<noeud id="55474978" latitude="45.761276" longitude="4.876554"/>
+<noeud id="25173820" latitude="45.749996" longitude="4.858258"/>
+<noeud id="640541652" latitude="45.751877" longitude="4.871223"/>
+<noeud id="195259" latitude="45.75095" longitude="4.859947"/>
+<noeud id="15925440" latitude="45.747505" longitude="4.857594"/>
+<noeud id="2650077854" latitude="45.753654" longitude="4.8593636"/>
+<noeud id="3509898986" latitude="45.753796" longitude="4.867863"/>
+<noeud id="2587463836" latitude="45.753925" longitude="4.859339"/>
+<noeud id="208769083" latitude="45.75947" longitude="4.870945"/>
+<noeud id="26079797" latitude="45.754993" longitude="4.8568406"/>
+<noeud id="2586814489" latitude="45.757202" longitude="4.8783083"/>
+<noeud id="21992980" latitude="45.748535" longitude="4.862575"/>
+<noeud id="25451370" latitude="45.750343" longitude="4.866599"/>
+<noeud id="26079798" latitude="45.754997" longitude="4.8572116"/>
+<noeud id="1679901326" latitude="45.762775" longitude="4.873984"/>
+<noeud id="25336254" latitude="45.751957" longitude="4.8713155"/>
+<noeud id="2587460578" latitude="45.75883" longitude="4.8659945"/>
+<noeud id="2587460577" latitude="45.758675" longitude="4.867718"/>
+<noeud id="80311393" latitude="45.75908" longitude="4.862537"/>
+<noeud id="26033326" latitude="45.756176" longitude="4.8582525"/>
+<noeud id="2034547839" latitude="45.7495" longitude="4.859674"/>
+<noeud id="1036842114" latitude="45.74993" longitude="4.8595204"/>
+<noeud id="26033324" latitude="45.757076" longitude="4.857407"/>
+<noeud id="2034547834" latitude="45.749058" longitude="4.8610687"/>
+<noeud id="25336247" latitude="45.75039" longitude="4.8738017"/>
+<noeud id="18697372" latitude="45.747116" longitude="4.859554"/>
+<noeud id="55475052" latitude="45.758472" longitude="4.8751354"/>
+<noeud id="474605986" latitude="45.747997" longitude="4.864131"/>
+<noeud id="3267479470" latitude="45.75974" longitude="4.872321"/>
+<noeud id="21992996" latitude="45.747612" longitude="4.86394"/>
+<noeud id="208769180" latitude="45.759502" longitude="4.872345"/>
+<noeud id="474605980" latitude="45.74871" longitude="4.8645"/>
+<noeud id="21992995" latitude="45.74773" longitude="4.8634377"/>
+<noeud id="2383442941" latitude="45.754566" longitude="4.861602"/>
+<noeud id="208769069" latitude="45.758217" longitude="4.8735127"/>
+<noeud id="25175819" latitude="45.754997" longitude="4.859137"/>
+<noeud id="342872879" latitude="45.760693" longitude="4.8777256"/>
+<noeud id="342873729" latitude="45.760193" longitude="4.8781986"/>
+<noeud id="474605974" latitude="45.748684" longitude="4.864619"/>
+<noeud id="21712143" latitude="45.74872" longitude="4.857905"/>
+<noeud id="208769295" latitude="45.759293" longitude="4.876936"/>
+<noeud id="3236267785" latitude="45.7578" longitude="4.878393"/>
+<noeud id="3509888072" latitude="45.753685" longitude="4.867738"/>
+<noeud id="2586814494" latitude="45.758804" longitude="4.878655"/>
+<noeud id="565368324" latitude="45.747086" longitude="4.8623657"/>
+<noeud id="2383442929" latitude="45.755955" longitude="4.861632"/>
+<noeud id="208769163" latitude="45.75964" longitude="4.872506"/>
+<noeud id="208769047" latitude="45.759624" longitude="4.8743205"/>
+<noeud id="1860559399" latitude="45.747787" longitude="4.874241"/>
+<noeud id="26316513" latitude="45.757706" longitude="4.870082"/>
+<noeud id="2841904735" latitude="45.74913" longitude="4.8594513"/>
+<noeud id="2477791932" latitude="45.74716" longitude="4.8587885"/>
+<noeud id="2383442939" latitude="45.75542" longitude="4.8616195"/>
+<noeud id="2841904730" latitude="45.749687" longitude="4.8594136"/>
+<noeud id="2383442931" latitude="45.755123" longitude="4.8616166"/>
+<noeud id="33066313" latitude="45.759087" longitude="4.861669"/>
+<noeud id="208769279" latitude="45.761482" longitude="4.869925"/>
+<noeud id="208769039" latitude="45.76069" longitude="4.8749375"/>
+<noeud id="26125366" latitude="45.7531" longitude="4.8704033"/>
+<noeud id="26079652" latitude="45.758354" longitude="4.864919"/>
+<noeud id="26079654" latitude="45.758083" longitude="4.8675914"/>
+<noeud id="26079653" latitude="45.758255" longitude="4.865917"/>
+<noeud id="208769145" latitude="45.7595" longitude="4.8722763"/>
+<noeud id="208769027" latitude="45.758717" longitude="4.8737717"/>
+<noeud id="251167391" latitude="45.74758" longitude="4.875293"/>
+<noeud id="26079656" latitude="45.75858" longitude="4.862883"/>
+<noeud id="26079655" latitude="45.757935" longitude="4.8685865"/>
+<noeud id="208822503" latitude="45.76229" longitude="4.869225"/>
+<noeud id="479185290" latitude="45.75072" longitude="4.858164"/>
+<noeud id="54803905" latitude="45.76194" longitude="4.8739953"/>
+<noeud id="21992964" latitude="45.74778" longitude="4.8682485"/>
+<noeud id="208769133" latitude="45.759453" longitude="4.8698664"/>
+<noeud id="342873658" latitude="45.76038" longitude="4.8775625"/>
+<noeud id="342873532" latitude="45.76051" longitude="4.8783274"/>
+<noeud id="208769499" latitude="45.760597" longitude="4.87622"/>
+<noeud id="975886496" latitude="45.756874" longitude="4.8574047"/>
+<troncon destination="25175778" longueur="69.979805" nomRue="Rue Danton" origine="25175791"/>
+<troncon destination="2117622723" longueur="136.00636" nomRue="Rue de l'Abondance" origine="25175791"/>
+<troncon destination="2129259180" longueur="25.26484" nomRue="" origine="2129259178"/>
+<troncon destination="25303831" longueur="118.890465" nomRue="Avenue Lacassagne" origine="2129259178"/>
+<troncon destination="208776568" longueur="67.38149" nomRue="Rue Sainte-Anne de Baraban" origine="26086130"/>
+<troncon destination="2129259173" longueur="26.899399" nomRue="" origine="2129259176"/>
+<troncon destination="251047560" longueur="88.17194" nomRue="Avenue Lacassagne" origine="2129259176"/>
+<troncon destination="479185309" longueur="127.57283" nomRue="Rue Philomène Magnin" origine="479185301"/>
+<troncon destination="479185290" longueur="76.625084" nomRue="Rue de l'Abbé Boisard" origine="479185301"/>
+<troncon destination="1036842196" longueur="50.411644" nomRue="Rue de l'Abbé Boisard" origine="479185301"/>
+<troncon destination="26317233" longueur="26.020561" nomRue="Avenue Félix Faure" origine="25611760"/>
+<troncon destination="26317214" longueur="73.66637" nomRue="Avenue Lacassagne" origine="25611760"/>
+<troncon destination="250042857" longueur="214.0224" nomRue="Avenue Félix Faure" origine="25611760"/>
+<troncon destination="25321456" longueur="64.89446" nomRue="Rue Feuillat" origine="25303831"/>
+<troncon destination="25321689" longueur="153.72511" nomRue="Rue Feuillat" origine="25303831"/>
+<troncon destination="2129259180" longueur="122.619156" nomRue="Rue Bara" origine="25303831"/>
+<troncon destination="25303832" longueur="91.81539" nomRue="Avenue Lacassagne" origine="25303831"/>
+<troncon destination="479185290" longueur="133.29784" nomRue="Rue Professeur René Guillet" origine="479185303"/>
+<troncon destination="479185309" longueur="75.256165" nomRue="Rue de la Buire" origine="479185303"/>
+<troncon destination="25303833" longueur="104.95519" nomRue="Avenue Lacassagne" origine="25303832"/>
+<troncon destination="2365376415" longueur="59.433758" nomRue="Avenue Lacassagne" origine="25303833"/>
+<troncon destination="33066313" longueur="7.2110343" nomRue="Avenue Georges Pompidou" origine="33066088"/>
+<troncon destination="2129259178" longueur="25.26484" nomRue="" origine="2129259180"/>
+<troncon destination="25336247" longueur="42.580826" nomRue="Rue Bara" origine="2129259180"/>
+<troncon destination="26086130" longueur="43.43769" nomRue="Rue Sainte-Anne de Baraban" origine="26316433"/>
+<troncon destination="254567104" longueur="64.74053" nomRue="Rue Riboud" origine="25468070"/>
+<troncon destination="25468041" longueur="70.17448" nomRue="Rue Riboud" origine="25468070"/>
+<troncon destination="26086114" longueur="75.166565" nomRue="Rue Maurice Flandin" origine="25468070"/>
+<troncon destination="26086122" longueur="136.39932" nomRue="Rue Roposte" origine="26086121"/>
+<troncon destination="48833743" longueur="62.881767" nomRue="Rue Étienne Richerand" origine="26086121"/>
+<troncon destination="48833747" longueur="61.05543" nomRue="Rue Baraban" origine="26086122"/>
+<troncon destination="26086117" longueur="104.15767" nomRue="Rue Baraban" origine="26086122"/>
+<troncon destination="25468067" longueur="77.947" nomRue="Rue Ternois" origine="26086120"/>
+<troncon destination="26086119" longueur="63.36733" nomRue="Rue d'Aubigny" origine="26086120"/>
+<troncon destination="26086115" longueur="60.97287" nomRue="Rue d'Aubigny" origine="26086120"/>
+<troncon destination="26086124" longueur="193.08192" nomRue="Avenue Georges Pompidou" origine="26086126"/>
+<troncon destination="48833748" longueur="94.98224" nomRue="Rue Gandolière" origine="26086126"/>
+<troncon destination="26086127" longueur="48.14814" nomRue="Avenue Georges Pompidou" origine="26086126"/>
+<troncon destination="26086117" longueur="104.1326" nomRue="Rue Baraban" origine="26086123"/>
+<troncon destination="26079656" longueur="57.778957" nomRue="Rue Maurice Flandin" origine="26086124"/>
+<troncon destination="80311393" longueur="32.83932" nomRue="Avenue Georges Pompidou" origine="26086124"/>
+<troncon destination="26086126" longueur="193.08192" nomRue="Avenue Georges Pompidou" origine="26086124"/>
+<troncon destination="26086128" longueur="29.557299" nomRue="Rue Baraban" origine="26086129"/>
+<troncon destination="2587460577" longueur="47.348785" nomRue="Rue Baraban" origine="26086129"/>
+<troncon destination="26576954" longueur="50.25232" nomRue="Grande Rue de la Guillotière" origine="25152444"/>
+<troncon destination="26576955" longueur="36.783928" nomRue="Grande Rue de la Guillotière" origine="25152444"/>
+<troncon destination="2477791932" longueur="41.447834" nomRue="Grande Rue de la Guillotière" origine="25152444"/>
+<troncon destination="26086128" longueur="140.42914" nomRue="Avenue Georges Pompidou" origine="26086127"/>
+<troncon destination="2587460578" longueur="51.051052" nomRue="Rue Étienne Richerand" origine="26086127"/>
+<troncon destination="26086126" longueur="48.14814" nomRue="Avenue Georges Pompidou" origine="26086127"/>
+<troncon destination="208769112" longueur="106.253914" nomRue="Avenue Georges Pompidou" origine="26086128"/>
+<troncon destination="26086129" longueur="29.557299" nomRue="Rue Baraban" origine="26086128"/>
+<troncon destination="48833747" longueur="53.631104" nomRue="Rue Baraban" origine="26086128"/>
+<troncon destination="26086127" longueur="140.42914" nomRue="Avenue Georges Pompidou" origine="26086128"/>
+<troncon destination="479185301" longueur="127.57283" nomRue="Rue Philomène Magnin" origine="479185309"/>
+<troncon destination="495424862" longueur="159.34192" nomRue="Rue Danielle Faÿnel Duclos Rue Philomène Magnin" origine="479185309"/>
+<troncon destination="208769120" longueur="68.82436" nomRue="Rue de Nazareth" origine="208776568"/>
+<troncon destination="26086129" longueur="138.84" nomRue="Rue Sainte-Anne de Baraban" origine="208776568"/>
+<troncon destination="25175778" longueur="86.8148" nomRue="Rue Professeur René Guillet" origine="495424862"/>
+<troncon destination="479185309" longueur="159.34192" nomRue="Rue Danielle Faÿnel Duclos Rue Philomène Magnin" origine="495424862"/>
+<troncon destination="479185303" longueur="86.1731" nomRue="Rue Professeur René Guillet" origine="495424862"/>
+<troncon destination="25611424" longueur="63.580322" nomRue="Route de Genas" origine="25611411"/>
+<troncon destination="26317310" longueur="91.03066" nomRue="Rue Claudius Penet" origine="25611411"/>
+<troncon destination="26316433" longueur="129.96458" nomRue="Rue Sainte-Anne de Baraban" origine="26316432"/>
+<troncon destination="25303833" longueur="148.15503" nomRue="Rue du Professeur Rochaix" origine="25303800"/>
+<troncon destination="55463812" longueur="21.551727" nomRue="Route de Genas" origine="25611425"/>
+<troncon destination="25611424" longueur="83.16971" nomRue="Route de Genas" origine="25611425"/>
+<troncon destination="55463792" longueur="104.732445" nomRue="Rue Meunier" origine="25611425"/>
+<troncon destination="26317293" longueur="238.35002" nomRue="Rue Feuillat" origine="25611425"/>
+<troncon destination="26317242" longueur="139.95462" nomRue="Rue du Dauphiné" origine="25611428"/>
+<troncon destination="26317260" longueur="180.70561" nomRue="Rue du Docteur Vaillant" origine="25611428"/>
+<troncon destination="1368674799" longueur="63.594482" nomRue="Rue du Dauphiné" origine="25611428"/>
+<troncon destination="25611425" longueur="83.16971" nomRue="Route de Genas" origine="25611424"/>
+<troncon destination="25611411" longueur="63.580322" nomRue="Route de Genas" origine="25611424"/>
+<troncon destination="26317294" longueur="234.77402" nomRue="Rue Bellicard" origine="25611424"/>
+<troncon destination="26057109" longueur="117.094574" nomRue="Rue Antoine Charial" origine="26316429"/>
+<troncon destination="522100855" longueur="70.188835" nomRue="Rue Rampon" origine="1345284783"/>
+<troncon destination="26317209" longueur="76.32593" nomRue="Rue de Carry" origine="26317212"/>
+<troncon destination="26317248" longueur="38.124634" nomRue="Rue du Dauphiné" origine="26317212"/>
+<troncon destination="26317242" longueur="110.82931" nomRue="Rue du Dauphiné" origine="26317212"/>
+<troncon destination="208769499" longueur="96.57731" nomRue="Rue Édouard Aynard" origine="55475018"/>
+<troncon destination="55475025" longueur="12.28458" nomRue="Place Marengo" origine="55475018"/>
+<troncon destination="55475004" longueur="28.9105" nomRue="Place Marengo" origine="55475018"/>
+<troncon destination="25321456" longueur="90.44906" nomRue="Rue Feuillat" origine="25321469"/>
+<troncon destination="195272" longueur="72.58715" nomRue="Rue du Professeur Paul Sisley" origine="25335981"/>
+<troncon destination="2069548810" longueur="207.19589" nomRue="Rue de Bonnel" origine="2069548756"/>
+<troncon destination="26317228" longueur="79.975136" nomRue="Rue de Carry" origine="26317209"/>
+<troncon destination="26317207" longueur="251.37651" nomRue="Rue de la Métallurgie" origine="26317209"/>
+<troncon destination="26317209" longueur="251.37651" nomRue="Rue de la Métallurgie" origine="26317207"/>
+<troncon destination="26125366" longueur="174.88742" nomRue="Rue David" origine="26317207"/>
+<troncon destination="26057106" longueur="120.3281" nomRue="Rue Paul Bert" origine="2672660419"/>
+<troncon destination="55475018" longueur="28.9105" nomRue="Place Marengo" origine="55475004"/>
+<troncon destination="55474989" longueur="14.101396" nomRue="Place Marengo" origine="55475004"/>
+<troncon destination="208769295" longueur="82.654625" nomRue="Avenue Antoine de Saint-Exupéry" origine="55475004"/>
+<troncon destination="1682387615" longueur="129.8884" nomRue="Impasse Belloeuf" origine="565375197"/>
+<troncon destination="26317248" longueur="32.646736" nomRue="Rue du Dauphiné" origine="565375197"/>
+<troncon destination="26125366" longueur="71.13966" nomRue="Rue du Dauphiné" origine="565375197"/>
+<troncon destination="25321334" longueur="20.22657" nomRue="Rue du Docteur Rebatel" origine="25321359"/>
+<troncon destination="25335974" longueur="341.72525" nomRue="Rue Saint-Maximin" origine="25321359"/>
+<troncon destination="26079800" longueur="23.776384" nomRue="Place Danton" origine="26079802"/>
+<troncon destination="2117622731" longueur="108.09743" nomRue="Rue du Pensionnat" origine="26079802"/>
+<troncon destination="250042857" longueur="345.9447" nomRue="Rue des Cadets de la France Libre Rue Jean-Pierre Lévy" origine="26317214"/>
+<troncon destination="3509898986" longueur="58.81714" nomRue="Avenue Lacassagne" origine="26317214"/>
+<troncon destination="26079802" longueur="24.764387" nomRue="Place Danton" origine="26079801"/>
+<troncon destination="25175791" longueur="88.53801" nomRue="Rue Danton" origine="26079801"/>
+<troncon destination="26079798" longueur="23.799927" nomRue="Place Danton" origine="26079800"/>
+<troncon destination="26317313" longueur="31.349016" nomRue="Rue Claudius Penet" origine="26317312"/>
+<troncon destination="26317313" longueur="87.10888" nomRue="Rue Claudius Penet" origine="26317310"/>
+<troncon destination="25611411" longueur="91.03066" nomRue="Rue Claudius Penet" origine="26317310"/>
+<troncon destination="459797864" longueur="71.58854" nomRue="Impasse Lacombe" origine="459797866"/>
+<troncon destination="459797866" longueur="71.58854" nomRue="Impasse Lacombe" origine="459797864"/>
+<troncon destination="26317246" longueur="80.7477" nomRue="Rue Villebois-Mareuil" origine="459797864"/>
+<troncon destination="55475025" longueur="19.43745" nomRue="Place Marengo" origine="55475038"/>
+<troncon destination="55474983" longueur="23.662092" nomRue="Place Marengo" origine="55475038"/>
+<troncon destination="208769047" longueur="91.837265" nomRue="Rue François Gillet" origine="55475038"/>
+<troncon destination="3370328152" longueur="67.72544" nomRue="Rue d'Aubigny" origine="26086114"/>
+<troncon destination="26086115" longueur="70.569046" nomRue="Rue d'Aubigny" origine="26086114"/>
+<troncon destination="26086124" longueur="252.46027" nomRue="Rue Maurice Flandin" origine="26086114"/>
+<troncon destination="26086120" longueur="60.97287" nomRue="Rue d'Aubigny" origine="26086115"/>
+<troncon destination="26086114" longueur="70.569046" nomRue="Rue d'Aubigny" origine="26086115"/>
+<troncon destination="25321687" longueur="101.035904" nomRue="Passage Feuillat" origine="459797860"/>
+<troncon destination="251047560" longueur="67.994415" nomRue="Rue de Domrémy" origine="459797860"/>
+<troncon destination="251047558" longueur="72.6692" nomRue="Rue de Domrémy" origine="459797860"/>
+<troncon destination="26086119" longueur="79.10604" nomRue="Rue d'Aubigny" origine="26086118"/>
+<troncon destination="26086121" longueur="79.720085" nomRue="Rue Étienne Richerand" origine="26086118"/>
+<troncon destination="26086117" longueur="138.79436" nomRue="Rue d'Aubigny" origine="26086118"/>
+<troncon destination="26086120" longueur="63.36733" nomRue="Rue d'Aubigny" origine="26086119"/>
+<troncon destination="26086118" longueur="79.10604" nomRue="Rue d'Aubigny" origine="26086119"/>
+<troncon destination="26086122" longueur="104.15767" nomRue="Rue Baraban" origine="26086117"/>
+<troncon destination="26086123" longueur="104.1326" nomRue="Rue Baraban" origine="26086117"/>
+<troncon destination="26086118" longueur="138.79436" nomRue="Rue d'Aubigny" origine="26086117"/>
+<troncon destination="208769279" longueur="128.86993" nomRue="Rue Saint-Victorien" origine="26086117"/>
+<troncon destination="92375975" longueur="63.53379" nomRue="Rue Paul Bert" origine="2117622744"/>
+<troncon destination="2117622742" longueur="98.99292" nomRue="Boulevard Vivier-Merle" origine="2117622744"/>
+<troncon destination="26057055" longueur="10.406557" nomRue="Rue Paul Bert" origine="2117622744"/>
+<troncon destination="2117622739" longueur="70.71593" nomRue="Boulevard Vivier-Merle" origine="2117622742"/>
+<troncon destination="26033326" longueur="40.810665" nomRue="Rue des Rancy" origine="2117622742"/>
+<troncon destination="55474973" longueur="114.625244" nomRue="Rue Pascal" origine="1679901320"/>
+<troncon destination="55475018" longueur="12.28458" nomRue="Place Marengo" origine="55475025"/>
+<troncon destination="55475038" longueur="19.43745" nomRue="Place Marengo" origine="55475025"/>
+<troncon destination="208769039" longueur="115.5685" nomRue="Avenue Marc Sangnier" origine="55475025"/>
+<troncon destination="25321687" longueur="76.26666" nomRue="Rue du Docteur Paul Diday" origine="25303840"/>
+<troncon destination="251050719" longueur="50.582382" nomRue="Impasse Jeanne d'Arc" origine="25303840"/>
+<troncon destination="54803122" longueur="206.64528" nomRue="Rue Claudius Pionchon" origine="208769091"/>
+<troncon destination="208769219" longueur="92.4231" nomRue="Place de la Ferrandière" origine="208769091"/>
+<troncon destination="25303840" longueur="151.94449" nomRue="Rue Jeanne d'Arc" origine="25303841"/>
+<troncon destination="25321689" longueur="83.108986" nomRue="Rue Feuillat" origine="25303841"/>
+<troncon destination="26317293" longueur="111.942184" nomRue="Rue Feuillat" origine="25303841"/>
+<troncon destination="195266" longueur="68.44089" nomRue="Rue Saint-Maximin" origine="25334442"/>
+<troncon destination="474605974" longueur="115.165535" nomRue="Rue Rossan" origine="25334442"/>
+<troncon destination="2117622731" longueur="63.25565" nomRue="Boulevard Vivier-Merle" origine="2117622739"/>
+<troncon destination="26033326" longueur="83.423706" nomRue="Rue Lavoisier" origine="2117622739"/>
+<troncon destination="25175819" longueur="10.355757" nomRue="Rue du Pensionnat" origine="2117622731"/>
+<troncon destination="2117622723" longueur="84.0667" nomRue="Boulevard Vivier-Merle" origine="2117622731"/>
+<troncon destination="25611760" longueur="214.0224" nomRue="Avenue Félix Faure" origine="250042857"/>
+<troncon destination="25336179" longueur="48.468773" nomRue="Avenue Félix Faure" origine="250042857"/>
+<troncon destination="249801845" longueur="29.81919" nomRue="Rue Kimmerling" origine="250042857"/>
+<troncon destination="26317312" longueur="31.349016" nomRue="Rue Claudius Penet" origine="26317313"/>
+<troncon destination="26317310" longueur="87.10888" nomRue="Rue Claudius Penet" origine="26317313"/>
+<troncon destination="21993017" longueur="194.25832" nomRue="Rue Saint-Théodore" origine="25321302"/>
+<troncon destination="195266" longueur="54.717278" nomRue="Rue du Dauphiné" origine="25321302"/>
+<troncon destination="195262" longueur="256.8284" nomRue="Rue du Dauphiné" origine="25321302"/>
+<troncon destination="25321408" longueur="15.331951" nomRue="Rue du Docteur Rebatel" origine="25321422"/>
+<troncon destination="1288817934" longueur="250.5025" nomRue="Rue de Montbrillant" origine="25321422"/>
+<troncon destination="195275" longueur="165.48785" nomRue="Rue Guilloud" origine="25321304"/>
+<troncon destination="1703401805" longueur="115.59021" nomRue="Rue des Tuiliers" origine="25321304"/>
+<troncon destination="342867241" longueur="67.77638" nomRue="Allée de l'Enfance" origine="342869317"/>
+<troncon destination="342868447" longueur="147.80559" nomRue="Allée du Couchant Allée de l'Enfance" origine="342869317"/>
+<troncon destination="3870641963" longueur="21.147356" nomRue="Rue de la Cité" origine="3870641969"/>
+<troncon destination="208769163" longueur="23.496798" nomRue="Rue de la Cité" origine="3870641969"/>
+<troncon destination="2650077854" longueur="70.70859" nomRue="Boulevard Vivier-Merle" origine="2117622723"/>
+<troncon destination="2587463836" longueur="72.46447" nomRue="Avenue Félix Faure" origine="2117622721"/>
+<troncon destination="195261" longueur="112.49038" nomRue="Avenue Félix Faure" origine="2117622721"/>
+<troncon destination="2650077854" longueur="62.200565" nomRue="Avenue Félix Faure" origine="2117622721"/>
+<troncon destination="195263" longueur="13.370239" nomRue="Rue du Général Mouton-Duvernet" origine="4428355731"/>
+<troncon destination="195261" longueur="348.3609" nomRue="Rue du Général Mouton-Duvernet" origine="4428355731"/>
+<troncon destination="25336175" longueur="514.477" nomRue="Rue Jeanne Hachette" origine="4428355731"/>
+<troncon destination="208769091" longueur="104.45981" nomRue="Place de la Ferrandière" origine="3870641963"/>
+<troncon destination="26317212" longueur="38.124634" nomRue="Rue du Dauphiné" origine="26317248"/>
+<troncon destination="565375197" longueur="32.646736" nomRue="Rue du Dauphiné" origine="26317248"/>
+<troncon destination="26057069" longueur="81.91166" nomRue="Rue Paul Bert" origine="26057083"/>
+<troncon destination="25321422" longueur="77.777405" nomRue="Rue du Docteur Rebatel" origine="25321433"/>
+<troncon destination="26317246" longueur="87.1567" nomRue="Impasse de la Ruche" origine="1682387619"/>
+<troncon destination="26057083" longueur="127.00451" nomRue="Rue Paul Bert" origine="26057084"/>
+<troncon destination="26079654" longueur="153.978" nomRue="Rue Baraban" origine="26057084"/>
+<troncon destination="26057084" longueur="84.381294" nomRue="Rue Paul Bert" origine="26057085"/>
+<troncon destination="26317229" longueur="232.252" nomRue="Rue Turbil" origine="26057085"/>
+<troncon destination="25611428" longueur="180.70561" nomRue="Rue du Docteur Vaillant" origine="26317260"/>
+<troncon destination="565375197" longueur="129.8884" nomRue="Impasse Belloeuf" origine="1682387615"/>
+<troncon destination="33066088" longueur="11.389886" nomRue="Rue de la Villette" origine="33065949"/>
+<troncon destination="80311393" longueur="63.56973" nomRue="Avenue Georges Pompidou" origine="33065949"/>
+<troncon destination="26057062" longueur="211.0173" nomRue="Rue de la Villette" origine="33065949"/>
+<troncon destination="1368674799" longueur="187.75513" nomRue="Rue Girié" origine="26317259"/>
+<troncon destination="2456932713" longueur="113.9548" nomRue="Rue Lafontaine" origine="342867241"/>
+<troncon destination="342869317" longueur="67.77638" nomRue="Allée de l'Enfance" origine="342867241"/>
+<troncon destination="26057106" longueur="93.64789" nomRue="Petite Rue Saint-Eusèbe" origine="26317234"/>
+<troncon destination="26317228" longueur="81.59183" nomRue="Avenue Félix Faure" origine="26317234"/>
+<troncon destination="55463805" longueur="226.60776" nomRue="Avenue Félix Faure" origine="26317234"/>
+<troncon destination="25611760" longueur="76.77519" nomRue="Avenue Lacassagne" origine="26317235"/>
+<troncon destination="26057098" longueur="145.27324" nomRue="Rue Meynis" origine="26317232"/>
+<troncon destination="26317228" longueur="70.396255" nomRue="Avenue Félix Faure" origine="26317232"/>
+<troncon destination="26317229" longueur="254.54216" nomRue="Avenue Félix Faure" origine="26317232"/>
+<troncon destination="25611760" longueur="26.020561" nomRue="Avenue Félix Faure" origine="26317233"/>
+<troncon destination="26057084" longueur="240.98518" nomRue="Rue Baraban" origine="26317233"/>
+<troncon destination="26317229" longueur="49.68636" nomRue="Avenue Félix Faure" origine="26317233"/>
+<troncon destination="25321689" longueur="153.3693" nomRue="Passage Feuillat" origine="25321687"/>
+<troncon destination="459797860" longueur="101.035904" nomRue="Passage Feuillat" origine="25321687"/>
+<troncon destination="25321447" longueur="103.34052" nomRue="Rue du Docteur Paul Diday" origine="25321687"/>
+<troncon destination="25321330" longueur="99.70037" nomRue="Rue de l'Harmonie" origine="25321327"/>
+<troncon destination="251167391" longueur="58.375137" nomRue="Rue Feuillat" origine="25321327"/>
+<troncon destination="2129259178" longueur="50.40357" nomRue="Avenue Lacassagne" origine="25321447"/>
+<troncon destination="25336247" longueur="32.53504" nomRue="Rue du Docteur Rebatel" origine="25321447"/>
+<troncon destination="25321687" longueur="153.3693" nomRue="Passage Feuillat" origine="25321689"/>
+<troncon destination="25303841" longueur="83.108986" nomRue="Rue Feuillat" origine="25321689"/>
+<troncon destination="25303831" longueur="153.72511" nomRue="Rue Feuillat" origine="25321689"/>
+<troncon destination="25468070" longueur="64.74053" nomRue="Rue Riboud" origine="254567104"/>
+<troncon destination="208769457" longueur="15.785075" nomRue="Rue Richelieu" origine="342868447"/>
+<troncon destination="208769312" longueur="82.82316" nomRue="Rue Richelieu" origine="342868447"/>
+<troncon destination="342869317" longueur="147.80559" nomRue="Allée du Couchant Allée de l'Enfance" origine="342868447"/>
+<troncon destination="25336179" longueur="357.00134" nomRue="Rue Maurice Flandin" origine="26057064"/>
+<troncon destination="26317236" longueur="164.15819" nomRue="Avenue Lacassagne" origine="26057064"/>
+<troncon destination="26057062" longueur="67.43828" nomRue="Rue Paul Bert" origine="26057064"/>
+<troncon destination="26317232" longueur="254.54216" nomRue="Avenue Félix Faure" origine="26317229"/>
+<troncon destination="26317233" longueur="49.68636" nomRue="Avenue Félix Faure" origine="26317229"/>
+<troncon destination="26317214" longueur="61.443684" nomRue="Place Rouget de l'Isle" origine="26317229"/>
+<troncon destination="26317207" longueur="109.498764" nomRue="Rue David" origine="26317229"/>
+<troncon destination="26317232" longueur="70.396255" nomRue="Avenue Félix Faure" origine="26317228"/>
+<troncon destination="26317234" longueur="81.59183" nomRue="Avenue Félix Faure" origine="26317228"/>
+<troncon destination="26057064" longueur="167.2197" nomRue="Rue Paul Bert" origine="26057069"/>
+<troncon destination="26079652" longueur="159.78378" nomRue="Rue Gabillot" origine="26057069"/>
+<troncon destination="1682387619" longueur="87.1567" nomRue="Impasse de la Ruche" origine="26317246"/>
+<troncon destination="26317248" longueur="215.509" nomRue="Rue de la Ruche" origine="26317246"/>
+<troncon destination="25321334" longueur="129.78181" nomRue="Rue de l'Harmonie" origine="25321330"/>
+<troncon destination="25321327" longueur="99.70037" nomRue="Rue de l'Harmonie" origine="25321330"/>
+<troncon destination="25321433" longueur="174.66516" nomRue="Rue Fiol" origine="25321456"/>
+<troncon destination="25303831" longueur="64.89446" nomRue="Rue Feuillat" origine="25321456"/>
+<troncon destination="459797864" longueur="89.59381" nomRue="Rue Villebois-Mareuil" origine="26317242"/>
+<troncon destination="26317212" longueur="110.82931" nomRue="Rue du Dauphiné" origine="26317242"/>
+<troncon destination="25611428" longueur="139.95462" nomRue="Rue du Dauphiné" origine="26317242"/>
+<troncon destination="25321330" longueur="129.78181" nomRue="Rue de l'Harmonie" origine="25321334"/>
+<troncon destination="26057064" longueur="67.43828" nomRue="Rue Paul Bert" origine="26057062"/>
+<troncon destination="2383442929" longueur="127.89951" nomRue="Rue du Général Mouton-Duvernet" origine="26057062"/>
+<troncon destination="33065949" longueur="211.0173" nomRue="Rue de la Villette" origine="26057062"/>
+<troncon destination="26057055" longueur="225.47935" nomRue="Rue Paul Bert" origine="26057062"/>
+<troncon destination="195273" longueur="85.42524" nomRue="Rue du Professeur Paul Sisley" origine="25335974"/>
+<troncon destination="195274" longueur="16.124802" nomRue="Rue Saint-Maximin" origine="25335974"/>
+<troncon destination="2117622744" longueur="10.406557" nomRue="Rue Paul Bert" origine="26057055"/>
+<troncon destination="26576964" longueur="71.57768" nomRue="Boulevard Vivier-Merle" origine="26057055"/>
+<troncon destination="26057062" longueur="225.47935" nomRue="Rue Paul Bert" origine="26057055"/>
+<troncon destination="975886496" longueur="15.188097" nomRue="Place Pierre Renaudel" origine="92375972"/>
+<troncon destination="26033324" longueur="27.423489" nomRue="Rue Lavoisier" origine="92375972"/>
+<troncon destination="26317235" longueur="177.07799" nomRue="Avenue Lacassagne" origine="26317236"/>
+<troncon destination="26057069" longueur="109.60838" nomRue="Rue Moissonnier" origine="26317236"/>
+<troncon destination="2117622744" longueur="63.53379" nomRue="Rue Paul Bert" origine="92375975"/>
+<troncon destination="26033324" longueur="29.939322" nomRue="Rue Paul Bert" origine="92375975"/>
+<troncon destination="92375972" longueur="22.408638" nomRue="Rue Lavoisier" origine="92375974"/>
+<troncon destination="92375975" longueur="40.51647" nomRue="Place Pierre Renaudel" origine="92375974"/>
+<troncon destination="25611424" longueur="234.77402" nomRue="Rue Bellicard" origine="26317294"/>
+<troncon destination="26317293" longueur="78.770195" nomRue="Rue Félix" origine="26317294"/>
+<troncon destination="2456932713" longueur="169.0433" nomRue="Rue Richelieu" origine="1423439485"/>
+<troncon destination="55457354" longueur="39.759953" nomRue="Rue Richelieu" origine="1423439485"/>
+<troncon destination="25303841" longueur="111.942184" nomRue="Rue Feuillat" origine="26317293"/>
+<troncon destination="25611425" longueur="238.35002" nomRue="Rue Feuillat" origine="26317293"/>
+<troncon destination="55463799" longueur="13.81556" nomRue="Rue Meunier" origine="55463792"/>
+<troncon destination="55463796" longueur="77.77078" nomRue="Place des Maisons Neuves" origine="55463792"/>
+<troncon destination="25468067" longueur="65.390274" nomRue="Rue Riboud" origine="25468041"/>
+<troncon destination="26086115" longueur="76.27878" nomRue="Rue Bellecombe" origine="25468041"/>
+<troncon destination="55463792" longueur="32.672306" nomRue="Place des Maisons Neuves" origine="55463789"/>
+<troncon destination="3393859904" longueur="197.8001" nomRue="Boulevard Vivier-Merle" origine="26576954"/>
+<troncon destination="26121686" longueur="115.87691" nomRue="Boulevard des Tchécoslovaques" origine="26576954"/>
+<troncon destination="26576953" longueur="26.196728" nomRue="Grande Rue de la Guillotière" origine="26576955"/>
+<troncon destination="2477791932" longueur="10.054522" nomRue="Boulevard des Tchécoslovaques" origine="26576955"/>
+<troncon destination="1368674809" longueur="11.871078" nomRue="Place des Maisons Neuves" origine="1368674810"/>
+<troncon destination="1368674811" longueur="11.389846" nomRue="Rue Frédéric Mistral" origine="1368674810"/>
+<troncon destination="55463805" longueur="52.7486" nomRue="Avenue Félix Faure" origine="1368674810"/>
+<troncon destination="26576954" longueur="26.16321" nomRue="Grande Rue de la Guillotière" origine="26576953"/>
+<troncon destination="18697372" longueur="34.76711" nomRue="Grande Rue de la Guillotière" origine="26576953"/>
+<troncon destination="1368674810" longueur="11.389846" nomRue="Rue Frédéric Mistral" origine="1368674811"/>
+<troncon destination="2672660419" longueur="150.36613" nomRue="Rue Paul Bert" origine="1368674811"/>
+<troncon destination="48830470" longueur="116.254364" nomRue="Rue Frédéric Mistral" origine="1368674811"/>
+<troncon destination="26316432" longueur="117.66286" nomRue="Rue de la Cité" origine="3870640550"/>
+<troncon destination="1368674810" longueur="61.247414" nomRue="Place des Maisons Neuves" origine="55463799"/>
+<troncon destination="33065924" longueur="27.023342" nomRue="Avenue Georges Pompidou" origine="26576965"/>
+<troncon destination="2069548756" longueur="343.10223" nomRue="Boulevard Vivier-Merle" origine="26576965"/>
+<troncon destination="25611424" longueur="149.72107" nomRue="Rue Rhonat" origine="55463796"/>
+<troncon destination="4193445730" longueur="99.45865" nomRue="Rue Jean Jaurès" origine="55463796"/>
+<troncon destination="55463799" longueur="75.874596" nomRue="Place des Maisons Neuves" origine="55463796"/>
+<troncon destination="2117622739" longueur="47.98013" nomRue="Rue Lavoisier" origine="26576963"/>
+<troncon destination="26057055" longueur="214.2913" nomRue="Boulevard Vivier-Merle" origine="26576963"/>
+<troncon destination="25303832" longueur="266.44214" nomRue="Rue Jules Verne" origine="251171098"/>
+<troncon destination="25303841" longueur="110.330574" nomRue="Rue Jeanne d'Arc" origine="251171098"/>
+<troncon destination="251171031" longueur="137.23657" nomRue="Rue de l'Est" origine="251171098"/>
+<troncon destination="33065924" longueur="122.99652" nomRue="Boulevard Vivier-Merle" origine="26576964"/>
+<troncon destination="26576965" longueur="123.08343" nomRue="Boulevard Vivier-Merle" origine="26576964"/>
+<troncon destination="2841904735" longueur="84.053215" nomRue="Boulevard des Tchécoslovaques" origine="26121686"/>
+<troncon destination="21712143" longueur="104.18585" nomRue="Rue Jules Brunard" origine="26121686"/>
+<troncon destination="1345284783" longueur="70.188835" nomRue="Rue Rampon" origine="522100855"/>
+<troncon destination="195271" longueur="197.0728" nomRue="Rue Roger Bréchan" origine="522100855"/>
+<troncon destination="25321469" longueur="191.91711" nomRue="Rue Élie Paris" origine="25321408"/>
+<troncon destination="25321407" longueur="46.197845" nomRue="Rue du Docteur Rebatel" origine="25321408"/>
+<troncon destination="25321359" longueur="85.53022" nomRue="Rue du Docteur Rebatel" origine="25321407"/>
+<troncon destination="565368324" longueur="86.49793" nomRue="Petite Rue de Monplaisir" origine="21993013"/>
+<troncon destination="21992995" longueur="76.79771" nomRue="Rue Édouard Rochet" origine="21993013"/>
+<troncon destination="21992980" longueur="75.947624" nomRue="Petite Rue de Monplaisir" origine="21993013"/>
+<troncon destination="208822503" longueur="124.96992" nomRue="Rue Saint-Sidoine" origine="54803125"/>
+<troncon destination="54803125" longueur="121.46178" nomRue="Rue du 14 Juillet 1789" origine="54803121"/>
+<troncon destination="54803119" longueur="98.74163" nomRue="Rue du Docteur Dolard" origine="54803121"/>
+<troncon destination="54803125" longueur="99.5104" nomRue="Rue Claudius Pionchon" origine="54803122"/>
+<troncon destination="54803119" longueur="123.30982" nomRue="Rue du 4 Septembre 1797 Rue Saint-Victorien" origine="54803122"/>
+<troncon destination="1368674810" longueur="11.871078" nomRue="Place des Maisons Neuves" origine="1368674809"/>
+<troncon destination="55463789" longueur="30.600428" nomRue="Place des Maisons Neuves" origine="1368674809"/>
+<troncon destination="1368674806" longueur="49.524254" nomRue="Place des Maisons Neuves" origine="1368674809"/>
+<troncon destination="1682387539" longueur="114.692825" nomRue="Rue des Prévoyants de l'Avenir" origine="251050862"/>
+<troncon destination="2129259173" longueur="114.30229" nomRue="Rue Bara" origine="251050862"/>
+<troncon destination="640541652" longueur="96.13519" nomRue="" origine="1603856892"/>
+<troncon destination="25336254" longueur="96.2063" nomRue="Avenue Lacassagne" origine="1603856892"/>
+<troncon destination="21992995" longueur="54.23289" nomRue="Rue Saint-Théodore" origine="21993017"/>
+<troncon destination="21992980" longueur="80.674286" nomRue="Cours Albert Thomas" origine="21993017"/>
+<troncon destination="195276" longueur="33.907093" nomRue="Rue des Tuiliers" origine="21993015"/>
+<troncon destination="3870641969" longueur="213.72795" nomRue="Rue de la Cité Rue du Docteur Dolard" origine="54803119"/>
+<troncon destination="54803122" longueur="123.30982" nomRue="Rue du 4 Septembre 1797 Rue Saint-Victorien" origine="54803119"/>
+<troncon destination="342867241" longueur="113.9548" nomRue="Rue Lafontaine" origine="2456932713"/>
+<troncon destination="55474978" longueur="107.5206" nomRue="Rue Lafontaine" origine="2456932713"/>
+<troncon destination="342872879" longueur="24.71337" nomRue="Rue Richelieu" origine="2456932713"/>
+<troncon destination="1423439485" longueur="169.0433" nomRue="Rue Richelieu" origine="2456932713"/>
+<troncon destination="33065949" longueur="235.9005" nomRue="Avenue Georges Pompidou" origine="33065924"/>
+<troncon destination="25611428" longueur="39.089375" nomRue="Rue du Dauphiné" origine="1368674802"/>
+<troncon destination="26057085" longueur="211.31693" nomRue="Rue Paul Bert" origine="26057098"/>
+<troncon destination="640541652" longueur="49.161777" nomRue="Rue Bara" origine="2129259173"/>
+<troncon destination="1368674799" longueur="36.126144" nomRue="Route de Genas" origine="1368674800"/>
+<troncon destination="55463812" longueur="68.41653" nomRue="Route de Genas" origine="1368674800"/>
+<troncon destination="1368674806" longueur="33.922108" nomRue="Place des Maisons Neuves" origine="1368674800"/>
+<troncon destination="1368674800" longueur="33.922108" nomRue="Place des Maisons Neuves" origine="1368674806"/>
+<troncon destination="1368674809" longueur="49.524254" nomRue="Place des Maisons Neuves" origine="1368674806"/>
+<troncon destination="1368674802" longueur="75.2092" nomRue="Rue du Dauphiné" origine="1368674806"/>
+<troncon destination="2034547839" longueur="15.589813" nomRue="Cours Albert Thomas" origine="3393859927"/>
+<troncon destination="3393859930" longueur="8.647819" nomRue="" origine="3393859927"/>
+<troncon destination="459797860" longueur="67.994415" nomRue="Rue de Domrémy" origine="251047560"/>
+<troncon destination="25321447" longueur="113.25773" nomRue="Avenue Lacassagne" origine="251047560"/>
+<troncon destination="1036842114" longueur="118.46849" nomRue="Boulevard Vivier-Merle" origine="1036842196"/>
+<troncon destination="479185301" longueur="50.411644" nomRue="Rue de l'Abbé Boisard" origine="1036842196"/>
+<troncon destination="25719228" longueur="7.7847524" nomRue="Rue du Général Mouton-Duvernet" origine="3393859920"/>
+<troncon destination="1036842078" longueur="74.09365" nomRue="Boulevard Vivier-Merle Cours Albert Thomas" origine="3393859920"/>
+<troncon destination="195262" longueur="53.857296" nomRue="Rue du Général Mouton-Duvernet" origine="3393859920"/>
+<troncon destination="195259" longueur="123.36402" nomRue="Boulevard Vivier-Merle" origine="1036842078"/>
+<troncon destination="208769133" longueur="10.284923" nomRue="Rue Nazareth" origine="208769120"/>
+<troncon destination="1423439485" longueur="44.850292" nomRue="Rue Richelieu" origine="55457354"/>
+<troncon destination="26079800" longueur="114.86338" nomRue="Rue Danton" origine="26033277"/>
+<troncon destination="26086114" longueur="67.72544" nomRue="Rue d'Aubigny" origine="3370328152"/>
+<troncon destination="2841904730" longueur="10.372925" nomRue="" origine="3393859930"/>
+<troncon destination="26086128" longueur="106.253914" nomRue="Avenue Georges Pompidou" origine="208769112"/>
+<troncon destination="208769120" longueur="39.416725" nomRue="Rue Nazareth" origine="208769112"/>
+<troncon destination="25303840" longueur="50.582382" nomRue="Impasse Jeanne d'Arc" origine="251050719"/>
+<troncon destination="1259561375" longueur="83.691925" nomRue="Rue Professeur Louis Roche" origine="1288817934"/>
+<troncon destination="25335981" longueur="144.92577" nomRue="Rue de Montbrillant" origine="1288817934"/>
+<troncon destination="459797860" longueur="72.6692" nomRue="Rue de Domrémy" origine="251047558"/>
+<troncon destination="195259" longueur="207.29044" nomRue="Boulevard Vivier-Merle" origine="3393859904"/>
+<troncon destination="55475052" longueur="54.468452" nomRue="Rue de l'Espérance" origine="48830472"/>
+<troncon destination="208769069" longueur="112.53927" nomRue="Rue Sainte-Anne de Baraban" origine="48830472"/>
+<troncon destination="26057098" longueur="126.56524" nomRue="Rue Paul Bert" origine="26057106"/>
+<troncon destination="26316429" longueur="138.28099" nomRue="Rue Saint-Eusèbe" origine="26057106"/>
+<troncon destination="1368674811" longueur="116.254364" nomRue="Rue Frédéric Mistral" origine="48830470"/>
+<troncon destination="48830471" longueur="90.98456" nomRue="Rue Frédéric Mistral" origine="48830470"/>
+<troncon destination="48830472" longueur="126.28599" nomRue="Rue Sainte-Anne de Baraban" origine="48830471"/>
+<troncon destination="48830474" longueur="90.38153" nomRue="Rue Frédéric Mistral" origine="48830471"/>
+<troncon destination="48830470" longueur="90.98456" nomRue="Rue Frédéric Mistral" origine="48830471"/>
+<troncon destination="48830472" longueur="100.56292" nomRue="Rue de l'Espérance" origine="26057109"/>
+<troncon destination="2672660419" longueur="128.7313" nomRue="Rue de l'Espérance" origine="26057109"/>
+<troncon destination="48830470" longueur="136.30344" nomRue="Rue Antoine Charial" origine="26057109"/>
+<troncon destination="1603856892" longueur="65.81088" nomRue="Avenue Lacassagne" origine="2026239409"/>
+<troncon destination="25336189" longueur="73.50747" nomRue="Rue du Dauphiné" origine="2026239409"/>
+<troncon destination="26125366" longueur="69.514244" nomRue="Rue du Dauphiné" origine="2026239409"/>
+<troncon destination="208769112" longueur="35.125885" nomRue="Place de la Ferrandière" origine="208769227"/>
+<troncon destination="208769120" longueur="16.263586" nomRue="Place de la Ferrandière" origine="208769227"/>
+<troncon destination="1368674809" longueur="52.383896" nomRue="Avenue Félix Faure" origine="55463805"/>
+<troncon destination="26317234" longueur="226.60776" nomRue="Avenue Félix Faure" origine="55463805"/>
+<troncon destination="2069548810" longueur="168.78093" nomRue="Rue de Bonnel" origine="26577743"/>
+<troncon destination="1368674800" longueur="36.126144" nomRue="Route de Genas" origine="1368674799"/>
+<troncon destination="1368674802" longueur="26.501734" nomRue="Rue du Dauphiné" origine="1368674799"/>
+<troncon destination="26317259" longueur="187.75513" nomRue="Rue Girié" origine="1368674799"/>
+<troncon destination="55474989" longueur="119.83992" nomRue="Avenue Marc Sangnier" origine="48830474"/>
+<troncon destination="208769334" longueur="86.07172" nomRue="Rue Richelieu" origine="48830474"/>
+<troncon destination="48830471" longueur="90.38153" nomRue="Rue Frédéric Mistral" origine="48830474"/>
+<troncon destination="48833748" longueur="58.243683" nomRue="Rue des Petites Sœurs" origine="48833743"/>
+<troncon destination="26086127" longueur="83.11128" nomRue="Rue Étienne Richerand" origine="48833743"/>
+<troncon destination="208769303" longueur="15.276517" nomRue="" origine="208769334"/>
+<troncon destination="208769295" longueur="12.193949" nomRue="" origine="208769334"/>
+<troncon destination="48830474" longueur="86.07172" nomRue="Rue Richelieu" origine="208769334"/>
+<troncon destination="26086122" longueur="61.05543" nomRue="Rue Baraban" origine="48833747"/>
+<troncon destination="48833743" longueur="138.0391" nomRue="Rue des Petites Sœurs" origine="48833747"/>
+<troncon destination="26086128" longueur="53.631104" nomRue="Rue Baraban" origine="48833747"/>
+<troncon destination="342873658" longueur="24.386381" nomRue="Rue Richelieu" origine="208769457"/>
+<troncon destination="208769499" longueur="106.73056" nomRue="Rue Frédéric Passy" origine="208769457"/>
+<troncon destination="342868447" longueur="15.785075" nomRue="Rue Richelieu" origine="208769457"/>
+<troncon destination="26086119" longueur="134.36157" nomRue="Rue Gandolière" origine="48833748"/>
+<troncon destination="251171098" longueur="137.23657" nomRue="Rue de l'Est" origine="251171031"/>
+<troncon destination="208769227" longueur="12.926414" nomRue="Place de la Ferrandière" origine="208769219"/>
+<troncon destination="208769279" longueur="211.55408" nomRue="Rue Louis Jasseron" origine="208769219"/>
+<troncon destination="25611425" longueur="21.551727" nomRue="Route de Genas" origine="55463812"/>
+<troncon destination="1368674800" longueur="68.41653" nomRue="Route de Genas" origine="55463812"/>
+<troncon destination="55463789" longueur="94.38046" nomRue="Rue Paul Pechoux" origine="55463812"/>
+<troncon destination="250042857" longueur="29.81919" nomRue="Rue Kimmerling" origine="249801845"/>
+<troncon destination="26317235" longueur="168.98726" nomRue="Rue Kimmerling" origine="249801845"/>
+<troncon destination="25451370" longueur="110.58808" nomRue="Rue des Tuiliers" origine="1703401805"/>
+<troncon destination="25334442" longueur="85.21657" nomRue="Rue Saint-Maximin" origine="1703401805"/>
+<troncon destination="25335981" longueur="75.26833" nomRue="Rue du Professeur Paul Sisley" origine="195271"/>
+<troncon destination="25336178" longueur="117.45386" nomRue="Rue du Dauphiné" origine="195270"/>
+<troncon destination="522100855" longueur="54.50388" nomRue="Rue Roger Bréchan" origine="195270"/>
+<troncon destination="3393859920" longueur="53.857296" nomRue="Rue du Général Mouton-Duvernet" origine="195262"/>
+<troncon destination="25321302" longueur="256.8284" nomRue="Rue du Dauphiné" origine="195262"/>
+<troncon destination="195263" longueur="100.00355" nomRue="Rue du Général Mouton-Duvernet" origine="195262"/>
+<troncon destination="2117622721" longueur="112.49038" nomRue="Avenue Félix Faure" origine="195261"/>
+<troncon destination="25336179" longueur="127.18727" nomRue="Avenue Félix Faure" origine="195261"/>
+<troncon destination="4428355731" longueur="348.3609" nomRue="Rue du Général Mouton-Duvernet" origine="195261"/>
+<troncon destination="2383442941" longueur="71.5091" nomRue="Rue du Général Mouton-Duvernet" origine="195261"/>
+<troncon destination="4428355731" longueur="13.370239" nomRue="Rue du Général Mouton-Duvernet" origine="195263"/>
+<troncon destination="195262" longueur="100.0792" nomRue="Rue du Général Mouton-Duvernet" origine="195263"/>
+<troncon destination="195268" longueur="96.7444" nomRue="Rue du Dauphiné" origine="195266"/>
+<troncon destination="25321302" longueur="54.717278" nomRue="Rue du Dauphiné" origine="195266"/>
+<troncon destination="4193445730" longueur="6.4504447" nomRue="Rue Jean Jaurès" origine="55463826"/>
+<troncon destination="195266" longueur="96.7444" nomRue="Rue du Dauphiné" origine="195268"/>
+<troncon destination="25451370" longueur="127.95288" nomRue="Rue Saint-Philippe" origine="195268"/>
+<troncon destination="195270" longueur="95.865654" nomRue="Rue du Dauphiné" origine="195268"/>
+<troncon destination="55463826" longueur="6.4504447" nomRue="Rue Jean Jaurès" origine="4193445730"/>
+<troncon destination="55463796" longueur="99.45865" nomRue="Rue Jean Jaurès" origine="4193445730"/>
+<troncon destination="4193445733" longueur="74.169395" nomRue="Rue Raymond Terracher" origine="4193445730"/>
+<troncon destination="251050862" longueur="114.692825" nomRue="Rue des Prévoyants de l'Avenir" origine="1682387539"/>
+<troncon destination="1288817934" longueur="83.691925" nomRue="Rue Professeur Louis Roche" origine="1259561375"/>
+<troncon destination="25336178" longueur="179.80255" nomRue="Rue Jean Renoir" origine="25336175"/>
+<troncon destination="25336179" longueur="129.12434" nomRue="Rue Jeanne Hachette" origine="25336175"/>
+<troncon destination="4428355731" longueur="514.477" nomRue="Rue Jeanne Hachette" origine="25336175"/>
+<troncon destination="25336189" longueur="222.6015" nomRue="Rue du Dauphiné" origine="25336178"/>
+<troncon destination="25336175" longueur="179.80255" nomRue="Rue Jean Renoir" origine="25336178"/>
+<troncon destination="2586814489" longueur="24.719471" nomRue="Rue Raymond Terracher" origine="4193445733"/>
+<troncon destination="4193445730" longueur="74.169395" nomRue="Rue Raymond Terracher" origine="4193445733"/>
+<troncon destination="3393859920" longueur="7.7847524" nomRue="Rue du Général Mouton-Duvernet" origine="25719228"/>
+<troncon destination="3393859930" longueur="66.13708" nomRue="Cours Albert Thomas" origine="25719228"/>
+<troncon destination="208769303" longueur="15.056885" nomRue="" origine="208769312"/>
+<troncon destination="208769295" longueur="9.775154" nomRue="" origine="208769312"/>
+<troncon destination="342868447" longueur="82.82316" nomRue="Rue Richelieu" origine="208769312"/>
+<troncon destination="195272" longueur="29.069725" nomRue="Rue du Professeur Paul Sisley" origine="195273"/>
+<troncon destination="195274" longueur="83.59344" nomRue="Rue du Professeur Paul Sisley" origine="195273"/>
+<troncon destination="25321407" longueur="362.365" nomRue="Rue des Dahlias" origine="195273"/>
+<troncon destination="195273" longueur="29.069725" nomRue="Rue du Professeur Paul Sisley" origine="195272"/>
+<troncon destination="25451370" longueur="154.44595" nomRue="Rue Saint-Philippe" origine="195272"/>
+<troncon destination="21992964" longueur="50.327866" nomRue="Rue Guilloud" origine="195275"/>
+<troncon destination="195275" longueur="115.403114" nomRue="Rue Villon" origine="195274"/>
+<troncon destination="1703401805" longueur="163.97949" nomRue="Rue Saint-Maximin" origine="195274"/>
+<troncon destination="25321304" longueur="95.299446" nomRue="Rue des Tuiliers" origine="195276"/>
+<troncon destination="474605986" longueur="94.638626" nomRue="Cours Albert Thomas" origine="195276"/>
+<troncon destination="2835339774" longueur="96.5331" nomRue="Impasse de l'Ordre" origine="2835339775"/>
+<troncon destination="26079654" longueur="61.78396" nomRue="Rue Antoine Charial" origine="2835339775"/>
+<troncon destination="2835339775" longueur="96.5331" nomRue="Impasse de l'Ordre" origine="2835339774"/>
+<troncon destination="55474989" longueur="12.930663" nomRue="Place Marengo" origine="55474983"/>
+<troncon destination="55475038" longueur="23.662092" nomRue="Place Marengo" origine="55474983"/>
+<troncon destination="2026239409" longueur="73.50747" nomRue="Rue du Dauphiné" origine="25336189"/>
+<troncon destination="195271" longueur="157.39076" nomRue="Rue du Professeur Paul Sisley" origine="25336189"/>
+<troncon destination="48830474" longueur="119.83992" nomRue="Avenue Marc Sangnier" origine="55474989"/>
+<troncon destination="55475004" longueur="14.101396" nomRue="Place Marengo" origine="55474989"/>
+<troncon destination="55474983" longueur="12.930663" nomRue="Place Marengo" origine="55474989"/>
+<troncon destination="479185290" longueur="98.039276" nomRue="Rue de l'Abbé Boisard" origine="25173835"/>
+<troncon destination="250042857" longueur="48.468773" nomRue="Avenue Félix Faure" origine="25336179"/>
+<troncon destination="195261" longueur="127.18727" nomRue="Avenue Félix Faure" origine="25336179"/>
+<troncon destination="25336175" longueur="129.12434" nomRue="Rue Jeanne Hachette" origine="25336179"/>
+<troncon destination="2586814494" longueur="127.41763" nomRue="Avenue Antoine de Saint-Exupéry" origine="208769303"/>
+<troncon destination="208769312" longueur="15.056885" nomRue="" origine="208769303"/>
+<troncon destination="208769334" longueur="15.276517" nomRue="" origine="208769303"/>
+<troncon destination="54803905" longueur="103.20281" nomRue="Rue Lafontaine" origine="55474973"/>
+<troncon destination="55474978" longueur="109.96871" nomRue="Rue Lafontaine" origine="55474973"/>
+<troncon destination="208769039" longueur="109.41269" nomRue="Rue Pascal" origine="55474973"/>
+<troncon destination="208769499" longueur="79.801414" nomRue="Rue Édouard Aynard" origine="55474978"/>
+<troncon destination="2456932713" longueur="107.5206" nomRue="Rue Lafontaine" origine="55474978"/>
+<troncon destination="55474973" longueur="109.96871" nomRue="Rue Lafontaine" origine="55474978"/>
+<troncon destination="21712143" longueur="144.76486" nomRue="Rue Pierre Robin" origine="25173820"/>
+<troncon destination="25173835" longueur="112.63291" nomRue="Cours Gambetta" origine="25173820"/>
+<troncon destination="25336254" longueur="11.288361" nomRue="Rue Bara" origine="640541652"/>
+<troncon destination="2650077854" longueur="304.3873" nomRue="Boulevard Vivier-Merle" origine="195259"/>
+<troncon destination="25152444" longueur="60.756367" nomRue="Grande Rue de la Guillotière" origine="15925440"/>
+<troncon destination="2117622721" longueur="62.200565" nomRue="Avenue Félix Faure" origine="2650077854"/>
+<troncon destination="1036842196" longueur="301.50327" nomRue="Boulevard Vivier-Merle" origine="2650077854"/>
+<troncon destination="2587463836" longueur="30.231571" nomRue="Boulevard Vivier-Merle" origine="2650077854"/>
+<troncon destination="25175778" longueur="149.44188" nomRue="Avenue Félix Faure" origine="2650077854"/>
+<troncon destination="3509888072" longueur="15.735389" nomRue="" origine="3509898986"/>
+<troncon destination="2026239409" longueur="175.30086" nomRue="Avenue Lacassagne" origine="3509898986"/>
+<troncon destination="2117622721" longueur="72.46447" nomRue="Avenue Félix Faure" origine="2587463836"/>
+<troncon destination="25175819" longueur="120.29985" nomRue="Boulevard Vivier-Merle" origine="2587463836"/>
+<troncon destination="26316433" longueur="94.49828" nomRue="Rue Claudius Pionchon" origine="208769083"/>
+<troncon destination="208769145" longueur="103.36165" nomRue="Rue Nazareth" origine="208769083"/>
+<troncon destination="26079798" longueur="28.791878" nomRue="Rue du Pensionnat" origine="26079797"/>
+<troncon destination="3236267785" longueur="66.92192" nomRue="Rue Raymond Terracher" origine="2586814489"/>
+<troncon destination="4193445733" longueur="24.719471" nomRue="Rue Raymond Terracher" origine="2586814489"/>
+<troncon destination="2034547834" longueur="130.47949" nomRue="Cours Albert Thomas" origine="21992980"/>
+<troncon destination="21993013" longueur="75.947624" nomRue="Petite Rue de Monplaisir" origine="21992980"/>
+<troncon destination="195272" longueur="154.44595" nomRue="Rue Saint-Philippe" origine="25451370"/>
+<troncon destination="195268" longueur="127.95288" nomRue="Rue Saint-Philippe" origine="25451370"/>
+<troncon destination="26079801" longueur="24.543253" nomRue="Place Danton" origine="26079798"/>
+<troncon destination="1679901320" longueur="123.51345" nomRue="Rue Clos Poncet" origine="1679901326"/>
+<troncon destination="54803905" longueur="92.98088" nomRue="Avenue Marc Sangnier" origine="1679901326"/>
+<troncon destination="2129259176" longueur="47.480927" nomRue="Avenue Lacassagne" origine="25336254"/>
+<troncon destination="26079653" longueur="64.645546" nomRue="Rue Étienne Richerand" origine="2587460578"/>
+<troncon destination="26086129" longueur="47.348785" nomRue="Rue Baraban" origine="2587460577"/>
+<troncon destination="2587460578" longueur="134.90417" nomRue="Rue des Teinturiers" origine="2587460577"/>
+<troncon destination="26079654" longueur="66.22617" nomRue="Rue Baraban" origine="2587460577"/>
+<troncon destination="33066088" longueur="60.452965" nomRue="Avenue Georges Pompidou" origine="80311393"/>
+<troncon destination="26086124" longueur="32.83932" nomRue="Avenue Georges Pompidou" origine="80311393"/>
+<troncon destination="26033277" longueur="65.436676" nomRue="Rue des Rancy" origine="26033326"/>
+<troncon destination="92375974" longueur="69.9046" nomRue="Rue Lavoisier" origine="26033326"/>
+<troncon destination="25719228" longueur="53.609547" nomRue="Rue du Général Mouton-Duvernet Cours Albert Thomas" origine="2034547839"/>
+<troncon destination="1036842078" longueur="26.84361" nomRue="" origine="1036842114"/>
+<troncon destination="2841904730" longueur="28.104166" nomRue="Boulevard Vivier-Merle" origine="1036842114"/>
+<troncon destination="975886496" longueur="22.768776" nomRue="Rue Danton" origine="26033324"/>
+<troncon destination="92375975" longueur="29.939322" nomRue="Rue Paul Bert" origine="26033324"/>
+<troncon destination="3393859920" longueur="73.04839" nomRue="Cours Albert Thomas" origine="2034547834"/>
+<troncon destination="25719228" longueur="70.048775" nomRue="Cours Albert Thomas" origine="2034547834"/>
+<troncon destination="25321433" longueur="82.277626" nomRue="Rue du Docteur Rebatel" origine="25336247"/>
+<troncon destination="251050862" longueur="101.70724" nomRue="Rue Bara" origine="25336247"/>
+<troncon destination="26576953" longueur="34.76711" nomRue="Grande Rue de la Guillotière" origine="18697372"/>
+<troncon destination="55474983" longueur="118.67187" nomRue="Rue Édouard Aynard" origine="55475052"/>
+<troncon destination="21993017" longueur="54.14699" nomRue="Cours Albert Thomas" origine="474605986"/>
+<troncon destination="474605980" longueur="84.36449" nomRue="Rue Rossan" origine="474605986"/>
+<troncon destination="3870641963" longueur="3.812855" nomRue="Place de la Ferrandière" origine="3267479470"/>
+<troncon destination="474605986" longueur="45.34168" nomRue="Rue Rossan" origine="21992996"/>
+<troncon destination="21993015" longueur="92.71113" nomRue="Rue Édouard Rochet" origine="21992996"/>
+<troncon destination="208769163" longueur="20.712637" nomRue="Rue Nazareth" origine="208769180"/>
+<troncon destination="3870640550" longueur="16.328531" nomRue="Rue de Nazareth" origine="208769180"/>
+<troncon destination="474605974" longueur="9.721205" nomRue="Rue Rossan" origine="474605980"/>
+<troncon destination="21992996" longueur="41.093044" nomRue="Rue Édouard Rochet" origine="21992995"/>
+<troncon destination="2383442931" longueur="63.2941" nomRue="Rue du Général Mouton-Duvernet" origine="2383442941"/>
+<troncon destination="195261" longueur="71.5091" nomRue="Rue du Général Mouton-Duvernet" origine="2383442941"/>
+<troncon destination="26316429" longueur="105.66926" nomRue="Impasse Saint-Eusèbe" origine="208769069"/>
+<troncon destination="26316432" longueur="74.09167" nomRue="Rue Sainte-Anne de Baraban" origine="208769069"/>
+<troncon destination="208769027" longueur="59.16955" nomRue="Rue Saint-Eusèbe" origine="208769069"/>
+<troncon destination="26576963" longueur="18.624685" nomRue="Boulevard Vivier-Merle" origine="25175819"/>
+<troncon destination="2456932713" longueur="24.71337" nomRue="Rue Richelieu" origine="342872879"/>
+<troncon destination="342873658" longueur="37.097897" nomRue="Rue Richelieu" origine="342872879"/>
+<troncon destination="342873532" longueur="51.028988" nomRue="Impasse Lafontaine" origine="342872879"/>
+<troncon destination="342873658" longueur="53.651497" nomRue="Impasse Richelieu" origine="342873729"/>
+<troncon destination="25321304" longueur="83.31093" nomRue="Rue Guilloud" origine="474605974"/>
+<troncon destination="474605980" longueur="9.721205" nomRue="Rue Rossan" origine="474605974"/>
+<troncon destination="15925440" longueur="137.15297" nomRue="Rue Pierre Robin" origine="21712143"/>
+<troncon destination="208769312" longueur="9.775154" nomRue="" origine="208769295"/>
+<troncon destination="208769334" longueur="12.193949" nomRue="" origine="208769295"/>
+<troncon destination="55475004" longueur="82.654625" nomRue="Avenue Antoine de Saint-Exupéry" origine="208769295"/>
+<troncon destination="4193445733" longueur="116.277916" nomRue="" origine="3236267785"/>
+<troncon destination="2586814489" longueur="195.75995" nomRue="Rue Jean-Louis Maubant" origine="3236267785"/>
+<troncon destination="2586814494" longueur="114.406746" nomRue="Rue Raymond Terracher" origine="3236267785"/>
+<troncon destination="3509898986" longueur="15.735389" nomRue="" origine="3509888072"/>
+<troncon destination="208769303" longueur="127.41763" nomRue="Avenue Antoine de Saint-Exupéry" origine="2586814494"/>
+<troncon destination="3236267785" longueur="114.406746" nomRue="Rue Raymond Terracher" origine="2586814494"/>
+<troncon destination="21993013" longueur="86.49793" nomRue="Petite Rue de Monplaisir" origine="565368324"/>
+<troncon destination="2383442939" longueur="60.350677" nomRue="Rue du Général Mouton-Duvernet" origine="2383442929"/>
+<troncon destination="26057062" longueur="127.89951" nomRue="Rue du Général Mouton-Duvernet" origine="2383442929"/>
+<troncon destination="3870640550" longueur="24.571829" nomRue="Rue de la Cité" origine="208769163"/>
+<troncon destination="3267479470" longueur="19.012548" nomRue="Place de la Ferrandière" origine="208769163"/>
+<troncon destination="208769047" longueur="140.8208" nomRue="Rue François Gillet" origine="208769163"/>
+<troncon destination="208769027" longueur="109.713776" nomRue="Rue Pascal" origine="208769047"/>
+<troncon destination="208769039" longueur="127.59808" nomRue="Rue Pascal" origine="208769047"/>
+<troncon destination="208769163" longueur="140.8208" nomRue="Rue François Gillet" origine="208769047"/>
+<troncon destination="55475038" longueur="91.837265" nomRue="Rue François Gillet" origine="208769047"/>
+<troncon destination="251167391" longueur="84.843506" nomRue="Impasse Gazagnon" origine="1860559399"/>
+<troncon destination="26086130" longueur="114.03479" nomRue="Rue Combet-Descombes" origine="26316513"/>
+<troncon destination="26316429" longueur="241.59207" nomRue="Rue Antoine Charial" origine="26316513"/>
+<troncon destination="2034547839" longueur="45.08708" nomRue="Boulevard des Tchécoslovaques" origine="2841904735"/>
+<troncon destination="3393859927" longueur="50.13689" nomRue="Boulevard des Tchécoslovaques" origine="2841904735"/>
+<troncon destination="2383442931" longueur="33.079563" nomRue="Rue du Général Mouton-Duvernet" origine="2383442939"/>
+<troncon destination="2383442929" longueur="60.239296" nomRue="Rue du Général Mouton-Duvernet" origine="2383442939"/>
+<troncon destination="3393859927" longueur="16.706312" nomRue="" origine="2841904730"/>
+<troncon destination="25173820" longueur="96.30125" nomRue="Cours Gambetta" origine="2841904730"/>
+<troncon destination="2383442939" longueur="33.079563" nomRue="Rue du Général Mouton-Duvernet" origine="2383442931"/>
+<troncon destination="2383442941" longueur="63.680832" nomRue="Rue du Général Mouton-Duvernet" origine="2383442931"/>
+<troncon destination="33065949" longueur="10.711094" nomRue="Rue de la Villette" origine="33066313"/>
+<troncon destination="26576965" longueur="259.48038" nomRue="Avenue Georges Pompidou" origine="33066313"/>
+<troncon destination="54803122" longueur="72.628426" nomRue="Rue Saint-Victorien" origine="208769279"/>
+<troncon destination="26086117" longueur="128.86993" nomRue="Rue Saint-Victorien" origine="208769279"/>
+<troncon destination="208769047" longueur="127.59808" nomRue="Rue Pascal" origine="208769039"/>
+<troncon destination="54803905" longueur="157.37244" nomRue="Avenue Marc Sangnier" origine="208769039"/>
+<troncon destination="208769499" longueur="100.48389" nomRue="Rue Frédéric Passy" origine="208769039"/>
+<troncon destination="55474973" longueur="109.41269" nomRue="Rue Pascal" origine="208769039"/>
+<troncon destination="55475025" longueur="115.5685" nomRue="Avenue Marc Sangnier" origine="208769039"/>
+<troncon destination="2026239409" longueur="69.514244" nomRue="Rue du Dauphiné" origine="26125366"/>
+<troncon destination="565375197" longueur="71.13966" nomRue="Rue du Dauphiné" origine="26125366"/>
+<troncon destination="26079653" longueur="78.23124" nomRue="Rue Antoine Charial" origine="26079652"/>
+<troncon destination="2587460577" longueur="66.22617" nomRue="Rue Baraban" origine="26079654"/>
+<troncon destination="26079655" longueur="79.02355" nomRue="Rue Antoine Charial" origine="26079654"/>
+<troncon destination="26057083" longueur="156.70116" nomRue="Rue Étienne Richerand" origine="26079653"/>
+<troncon destination="2835339775" longueur="69.480034" nomRue="Rue Antoine Charial" origine="26079653"/>
+<troncon destination="208769180" longueur="5.3707037" nomRue="Rue Nazareth" origine="208769145"/>
+<troncon destination="3267479470" longueur="29.410686" nomRue="Place de la Ferrandière" origine="208769145"/>
+<troncon destination="208769047" longueur="109.713776" nomRue="Rue Pascal" origine="208769027"/>
+<troncon destination="55475052" longueur="109.26013" nomRue="" origine="208769027"/>
+<troncon destination="208769069" longueur="59.16955" nomRue="Rue Saint-Eusèbe" origine="208769027"/>
+<troncon destination="25321469" longueur="92.586105" nomRue="Rue Feuillat" origine="251167391"/>
+<troncon destination="1860559399" longueur="84.843506" nomRue="Impasse Gazagnon" origine="251167391"/>
+<troncon destination="26057064" longueur="174.16241" nomRue="Rue Maurice Flandin" origine="26079656"/>
+<troncon destination="26079652" longueur="160.01234" nomRue="Rue Antoine Charial" origine="26079656"/>
+<troncon destination="26316513" longueur="118.77753" nomRue="Rue Antoine Charial" origine="26079655"/>
+<troncon destination="26057085" longueur="145.00984" nomRue="Rue Turbil" origine="26079655"/>
+<troncon destination="26086123" longueur="56.935192" nomRue="Rue Saint-Sidoine" origine="208822503"/>
+<troncon destination="25173835" longueur="98.039276" nomRue="Rue de l'Abbé Boisard" origine="479185290"/>
+<troncon destination="479185301" longueur="76.625084" nomRue="Rue de l'Abbé Boisard" origine="479185290"/>
+<troncon destination="54803119" longueur="124.02671" nomRue="Rue du 4 Septembre 1797" origine="54803905"/>
+<troncon destination="208769039" longueur="157.37244" nomRue="Avenue Marc Sangnier" origine="54803905"/>
+<troncon destination="55474973" longueur="103.20281" nomRue="Rue Lafontaine" origine="54803905"/>
+<troncon destination="1679901326" longueur="92.98088" nomRue="Avenue Marc Sangnier" origine="54803905"/>
+<troncon destination="25321357" longueur="172.6005" nomRue="Rue Guilloud" origine="21992964"/>
+<troncon destination="25335974" longueur="119.90758" nomRue="Rue du Professeur Paul Sisley" origine="21992964"/>
+<troncon destination="208769083" longueur="83.729836" nomRue="Rue Nazareth" origine="208769133"/>
+<troncon destination="208769219" longueur="20.79932" nomRue="Rue Louis Jasseron" origine="208769133"/>
+<troncon destination="342873729" longueur="53.651497" nomRue="Impasse Richelieu" origine="342873658"/>
+<troncon destination="342872879" longueur="37.097897" nomRue="Rue Richelieu" origine="342873658"/>
+<troncon destination="208769457" longueur="24.386381" nomRue="Rue Richelieu" origine="342873658"/>
+<troncon destination="342872879" longueur="51.028988" nomRue="Impasse Lafontaine" origine="342873532"/>
+<troncon destination="208769457" longueur="106.73056" nomRue="Rue Frédéric Passy" origine="208769499"/>
+<troncon destination="55474978" longueur="79.801414" nomRue="Rue Édouard Aynard" origine="208769499"/>
+<troncon destination="55475018" longueur="96.57731" nomRue="Rue Édouard Aynard" origine="208769499"/>
+<troncon destination="26033277" longueur="-10" nomRue="Rue Danton" origine="975886496"/>
+</reseau>
+


### PR DESCRIPTION
Le lecteur XML ne peut plus lire n'importe comment. Ses tests sont implémentés.

Certains états empêchent également de faire du undo/redo désormais.